### PR TITLE
feat: Fase 2 — Editor, Mídia e Tipos Especiais de Questão

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,54 @@
+name: CI
+
+on:
+  pull_request:
+    branches: [main]
+  push:
+    branches: [main]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  type-check:
+    name: type-check
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 10.2.1
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Type-check all packages
+        run: pnpm type-check
+
+  build:
+    name: build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 10.2.1
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Build all packages
+        run: pnpm build

--- a/packages/client/src/components/board/GameBoard.tsx
+++ b/packages/client/src/components/board/GameBoard.tsx
@@ -3,11 +3,12 @@ import type { Category } from '@jeopardy/shared';
 
 interface Props {
   categories: Category[];
+  gameId?: string;
   onSelectQuestion?: (categoryId: string, questionId: string) => void;
   activeQuestionId?: string | null;
 }
 
-export function GameBoard({ categories, onSelectQuestion, activeQuestionId }: Props) {
+export function GameBoard({ categories, gameId, onSelectQuestion, activeQuestionId }: Props) {
   return (
     <div
       className="grid gap-1 w-full"
@@ -20,7 +21,7 @@ export function GameBoard({ categories, onSelectQuestion, activeQuestionId }: Pr
           className="bg-jeopardy-blue-light border-4 border-slate-800 flex items-center justify-center text-center p-3 min-h-[80px]"
         >
           {cat.media ? (
-            <img src={`/media/${cat.media.filename}`} alt={cat.name} className="max-h-16 object-contain" />
+            <img src={`/media/${gameId}/${cat.media.filename}`} alt={cat.name} className="max-h-16 object-contain" />
           ) : (
             <span className="font-bold text-jeopardy-gold uppercase text-sm leading-tight">
               {cat.name}

--- a/packages/client/src/hooks/useSocketEvents.ts
+++ b/packages/client/src/hooks/useSocketEvents.ts
@@ -30,6 +30,15 @@ export function useSocketEvents() {
       store.setActiveQuestion(activeQuestion);
       store.setPhase(phase);
       setBuzzerPosition(null);
+      // Limpar estado de tipos especiais ao selecionar nova questão
+      store.setDoubleAssigned(null, null);
+      store.setChallengeState(null);
+    });
+
+    socket.on('question:answerReveal', ({ phase }) => {
+      store.setPhase(phase);
+      store.setBuzzerQueue([]);
+      setBuzzerPosition(null);
     });
 
     socket.on('question:closed', ({ categoryId, questionId, phase }) => {
@@ -105,6 +114,22 @@ export function useSocketEvents() {
       store.setPhase('game_over');
     });
 
+    socket.on('double:started', ({ assignedPlayerId, assignedPlayerName }) => {
+      store.setDoubleAssigned(assignedPlayerId, assignedPlayerName);
+      // Garantir fase double_wager caso o evento chegue após question:selected
+      if (assignedPlayerId) {
+        // Fase já foi setada via question:selected — só atualiza o player atribuído
+      }
+    });
+
+    socket.on('double:wagerLocked', ({ amount }) => {
+      store.setDoubleWagerLocked(amount);
+    });
+
+    socket.on('challenge:assigned', ({ challengeState }) => {
+      store.setChallengeState(challengeState);
+    });
+
     socket.on('error', ({ code, message }) => {
       console.error(`[socket error] ${code}: ${message}`);
     });
@@ -115,6 +140,7 @@ export function useSocketEvents() {
       socket.off('player:left');
       socket.off('game:started');
       socket.off('question:selected');
+      socket.off('question:answerReveal');
       socket.off('question:closed');
       socket.off('buzzer:opened');
       socket.off('buzzer:confirmed');
@@ -128,6 +154,9 @@ export function useSocketEvents() {
       socket.off('final:hostWagerReceived');
       socket.off('final:revealed');
       socket.off('game:over');
+      socket.off('double:started');
+      socket.off('double:wagerLocked');
+      socket.off('challenge:assigned');
       socket.off('error');
       // Não desconecta — conexão persiste durante toda a sessão de jogo
     };

--- a/packages/client/src/store/gameStore.ts
+++ b/packages/client/src/store/gameStore.ts
@@ -5,6 +5,7 @@ import type {
   GamePhase,
   ActiveQuestion,
   BuzzerEntry,
+  ChallengeState,
 } from '@jeopardy/shared';
 
 interface TimerState {
@@ -51,6 +52,14 @@ interface GameState {
   hostWagers: Record<string, HostWager>;    // detalhes das apostas (só host recebe)
   revealedWagers: Record<string, boolean>;  // quais jogadores já foram revelados
 
+  // Dupla Aposta
+  doublePlayerId: string | null;
+  doublePlayerName: string | null;
+  doubleWager: number | null;
+
+  // Challenge
+  challengeState: ChallengeState | null;
+
   // Ações
   setSession: (sessionId: string, hostToken: string | null, tunnelUrl: string | null, isHost: boolean) => void;
   setGameStarted: (config: Omit<GameConfig, 'finalChallengeAnswer'>, players: Player[]) => void;
@@ -66,6 +75,9 @@ interface GameState {
   addHostWager: (wager: HostWager) => void;
   markWagerRevealed: (playerId: string) => void;
   setMyWagerSent: () => void;
+  setDoubleAssigned: (playerId: string | null, playerName: string | null) => void;
+  setDoubleWagerLocked: (wager: number) => void;
+  setChallengeState: (state: ChallengeState | null) => void;
   reset: () => void;
 }
 
@@ -87,6 +99,10 @@ const initialState = {
   finalCorrectAnswer: null,
   hostWagers: {},
   revealedWagers: {},
+  doublePlayerId: null,
+  doublePlayerName: null,
+  doubleWager: null,
+  challengeState: null,
 };
 
 export const useGameStore = create<GameState>((set) => ({
@@ -147,6 +163,13 @@ export const useGameStore = create<GameState>((set) => ({
     set((s) => ({ revealedWagers: { ...s.revealedWagers, [playerId]: true } })),
 
   setMyWagerSent: () => set({ myWagerSent: true }),
+
+  setDoubleAssigned: (doublePlayerId, doublePlayerName) =>
+    set({ doublePlayerId, doublePlayerName }),
+
+  setDoubleWagerLocked: (doubleWager) => set({ doubleWager }),
+
+  setChallengeState: (challengeState) => set({ challengeState }),
 
   reset: () => set(initialState),
 }));

--- a/packages/client/src/views/HostSetupView.tsx
+++ b/packages/client/src/views/HostSetupView.tsx
@@ -3,7 +3,7 @@ import { useNavigate } from 'react-router-dom';
 import { socket } from '../socket.js';
 import { useGameStore } from '../store/gameStore.js';
 import { usePlayerStore } from '../store/playerStore.js';
-import type { GameConfig } from '@jeopardy/shared';
+import { ConfirmModal } from '../components/ui/ConfirmModal.js';
 
 interface GameSummary {
   id: string;
@@ -20,12 +20,18 @@ export function HostSetupView() {
   const [selected, setSelected] = useState<string | null>(null);
   const [error, setError] = useState('');
   const [loading, setLoading] = useState(false);
+  const [deleteTarget, setDeleteTarget] = useState<GameSummary | null>(null);
+  const [deleting, setDeleting] = useState(false);
 
-  useEffect(() => {
+  function loadGames() {
     fetch('/api/games')
       .then((r) => r.json())
       .then(setGames)
       .catch(() => setGames([]));
+  }
+
+  useEffect(() => {
+    loadGames();
   }, []);
 
   function handleHost() {
@@ -50,6 +56,21 @@ export function HostSetupView() {
     });
   }
 
+  async function confirmDelete() {
+    if (!deleteTarget) return;
+    setDeleting(true);
+    try {
+      await fetch(`/api/games/${deleteTarget.id}`, { method: 'DELETE' });
+      if (selected === deleteTarget.id) setSelected(null);
+      setGames((gs) => gs.filter((g) => g.id !== deleteTarget.id));
+    } catch {
+      setError('Erro ao deletar jogo');
+    } finally {
+      setDeleting(false);
+      setDeleteTarget(null);
+    }
+  }
+
   return (
     <div className="min-h-screen flex flex-col items-center justify-center p-6">
       <div className="w-full max-w-2xl">
@@ -65,21 +86,39 @@ export function HostSetupView() {
         ) : (
           <div className="flex flex-col gap-3 mb-6">
             {games.map((g) => (
-              <button
+              <div
                 key={g.id}
                 onClick={() => setSelected(g.id)}
-                className={`card text-left transition-all ${
+                className={`card cursor-pointer transition-all ${
                   selected === g.id
                     ? 'border-jeopardy-gold bg-jeopardy-blue-light'
                     : 'border-slate-600 hover:border-slate-500'
                 }`}
               >
-                <div className="font-bold text-lg">{g.name}</div>
-                {g.description && <div className="text-slate-400 text-sm mt-1">{g.description}</div>}
-                <div className="text-slate-500 text-xs mt-2">
-                  Atualizado: {new Date(g.updatedAt).toLocaleDateString('pt-BR')}
+                <div className="flex items-start justify-between gap-3">
+                  <div className="flex-1 min-w-0">
+                    <div className="font-bold text-lg truncate">{g.name}</div>
+                    {g.description && <div className="text-slate-400 text-sm mt-1">{g.description}</div>}
+                    <div className="text-slate-500 text-xs mt-2">
+                      Atualizado: {new Date(g.updatedAt).toLocaleDateString('pt-BR')}
+                    </div>
+                  </div>
+                  <div className="flex gap-2 flex-shrink-0" onClick={(e) => e.stopPropagation()}>
+                    <button
+                      className="text-xs py-1 px-3 border border-slate-500 text-slate-300 hover:border-jeopardy-gold hover:text-jeopardy-gold rounded-lg transition-colors"
+                      onClick={() => navigate(`/editor/${g.id}`)}
+                    >
+                      Editar
+                    </button>
+                    <button
+                      className="text-xs py-1 px-3 border border-red-500 text-red-400 hover:bg-red-500 hover:text-white rounded-lg transition-colors"
+                      onClick={() => setDeleteTarget(g)}
+                    >
+                      Deletar
+                    </button>
+                  </div>
                 </div>
-              </button>
+              </div>
             ))}
           </div>
         )}
@@ -104,6 +143,17 @@ export function HostSetupView() {
           </button>
         </div>
       </div>
+
+      <ConfirmModal
+        open={!!deleteTarget}
+        title={`Deletar "${deleteTarget?.name}"?`}
+        description="O jogo e todas as mídias serão deletados permanentemente. Esta ação não pode ser desfeita."
+        confirmLabel={deleting ? 'Deletando...' : 'Deletar'}
+        cancelLabel="Cancelar"
+        danger
+        onConfirm={confirmDelete}
+        onCancel={() => setDeleteTarget(null)}
+      />
     </div>
   );
 }

--- a/packages/client/src/views/LandingView.tsx
+++ b/packages/client/src/views/LandingView.tsx
@@ -37,6 +37,7 @@ export function LandingView() {
     socket.once('error', ({ message }) => {
       setError(message);
       setIsJoining(false);
+      socket.off('player:joined');
       socket.disconnect();
     });
   }

--- a/packages/client/src/views/editor/EditorView.tsx
+++ b/packages/client/src/views/editor/EditorView.tsx
@@ -1,7 +1,7 @@
 import { useState, useEffect } from 'react';
 import { useNavigate, useParams } from 'react-router-dom';
 const randomUUID = () => crypto.randomUUID();
-import type { GameConfig, Category, Question } from '@jeopardy/shared';
+import type { GameConfig, Category, Question, MediaAsset } from '@jeopardy/shared';
 
 const DEFAULT_VALUES = [100, 200, 300, 400, 500];
 
@@ -34,6 +34,89 @@ function emptyGame(): Omit<GameConfig, 'id' | 'version' | 'createdAt' | 'updated
     finalChallengeClue: '',
     finalChallengeAnswer: '',
   };
+}
+
+interface MediaUploadProps {
+  gameId: string;
+  media?: MediaAsset;
+  label?: string;
+  accept?: string;
+  onUpload: (asset: MediaAsset) => void;
+  onRemove: () => void;
+}
+
+function MediaUpload({ gameId, media, label = '+ Mídia', accept = 'image/*,audio/*', onUpload, onRemove }: MediaUploadProps) {
+  const [uploading, setUploading] = useState(false);
+  const [uploadError, setUploadError] = useState('');
+
+  async function handleFile(e: React.ChangeEvent<HTMLInputElement>) {
+    const file = e.target.files?.[0];
+    if (!file) return;
+
+    if (media) {
+      await fetch(`/api/games/${gameId}/media/${media.filename}`, { method: 'DELETE' }).catch(() => {});
+    }
+
+    setUploading(true);
+    setUploadError('');
+    try {
+      const form = new FormData();
+      form.append('file', file);
+      const res = await fetch(`/api/games/${gameId}/media`, { method: 'POST', body: form });
+      if (!res.ok) {
+        const data = await res.json();
+        setUploadError(data.error ?? 'Erro ao enviar');
+      } else {
+        const { filename, type } = await res.json();
+        onUpload({ type: type as MediaAsset['type'], filename });
+      }
+    } catch {
+      setUploadError('Erro ao enviar');
+    } finally {
+      setUploading(false);
+      e.target.value = '';
+    }
+  }
+
+  async function handleRemove() {
+    if (!media) return;
+    await fetch(`/api/games/${gameId}/media/${media.filename}`, { method: 'DELETE' }).catch(() => {});
+    onRemove();
+  }
+
+  if (media) {
+    return (
+      <div className="flex items-center gap-2 mt-1">
+        {media.type === 'audio' ? (
+          <audio src={`/media/${gameId}/${media.filename}`} controls className="h-10 max-w-[200px]" />
+        ) : (
+          <img src={`/media/${gameId}/${media.filename}`} alt="" className="h-12 w-auto rounded object-cover border border-slate-600" />
+        )}
+        <label className="cursor-pointer btn-ghost text-xs py-1 px-2">
+          {uploading ? 'Enviando...' : 'Trocar'}
+          <input type="file" accept={accept} className="hidden" onChange={handleFile} disabled={uploading} />
+        </label>
+        <button
+          type="button"
+          onClick={handleRemove}
+          className="text-red-400 text-xs hover:text-red-300 border border-red-400 rounded px-2 py-1"
+        >
+          Remover
+        </button>
+        {uploadError && <span className="text-red-400 text-xs">{uploadError}</span>}
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex items-center gap-2 mt-1">
+      <label className="cursor-pointer btn-ghost text-xs py-1 px-2">
+        {uploading ? 'Enviando...' : label}
+        <input type="file" accept={accept} className="hidden" onChange={handleFile} disabled={uploading} />
+      </label>
+      {uploadError && <span className="text-red-400 text-xs">{uploadError}</span>}
+    </div>
+  );
 }
 
 export function EditorView() {
@@ -93,6 +176,35 @@ export function EditorView() {
     setSelectedCat((c) => Math.min(c, game.categories.length - 2));
   }
 
+  function addQuestion(catIdx: number) {
+    setGame((g) => {
+      const cat = g.categories[catIdx];
+      if (cat.questions.length >= 10) return g;
+      const lastValue = cat.questions[cat.questions.length - 1]?.value ?? 0;
+      const newValue = lastValue + 100;
+      const newQ = emptyQuestion(newValue);
+      return {
+        ...g,
+        categories: g.categories.map((c, i) =>
+          i === catIdx ? { ...c, questions: [...c.questions, newQ] } : c,
+        ),
+      };
+    });
+  }
+
+  function removeQuestion(catIdx: number, qIdx: number) {
+    setGame((g) => {
+      const cat = g.categories[catIdx];
+      if (cat.questions.length <= 1) return g;
+      return {
+        ...g,
+        categories: g.categories.map((c, i) =>
+          i === catIdx ? { ...c, questions: c.questions.filter((_, qi) => qi !== qIdx) } : c,
+        ),
+      };
+    });
+  }
+
   async function save() {
     setSaving(true);
     setError('');
@@ -107,6 +219,9 @@ export function EditorView() {
       if (!res.ok) {
         const data = await res.json();
         setError(data.error ?? 'Erro ao salvar');
+      } else if (!gameId) {
+        const created: GameConfig = await res.json();
+        navigate(`/editor/${created.id}`);
       } else {
         navigate('/host');
       }
@@ -131,11 +246,27 @@ export function EditorView() {
           className="flex-1 bg-jeopardy-blue-light border-2 border-jeopardy-gold rounded-lg px-4 py-2 text-white text-xl font-bold focus:outline-none"
         />
         <button className="btn-primary" onClick={save} disabled={saving || !game.name.trim()}>
-          {saving ? 'Salvando...' : 'Salvar'}
+          {saving ? 'Salvando...' : gameId ? 'Salvar' : 'Criar e Continuar'}
         </button>
       </div>
 
       {error && <p className="text-red-400 text-center">{error}</p>}
+
+      {/* Descrição */}
+      <input
+        type="text"
+        placeholder="Descrição (opcional)"
+        value={game.description}
+        onChange={(e) => setGame((g) => ({ ...g, description: e.target.value }))}
+        maxLength={500}
+        className="bg-jeopardy-blue-light border border-slate-500 rounded-lg px-4 py-2 text-slate-300 text-sm focus:outline-none focus:border-jeopardy-gold"
+      />
+
+      {!gameId && (
+        <p className="text-slate-400 text-xs text-center">
+          Salve o jogo primeiro para poder adicionar imagens às questões.
+        </p>
+      )}
 
       <div className="flex gap-4 flex-1">
         {/* Sidebar de categorias */}
@@ -168,6 +299,17 @@ export function EditorView() {
                 onChange={(e) => updateCategory(selectedCat, { name: e.target.value })}
                 className="flex-1 bg-jeopardy-blue-light border-2 border-slate-500 rounded-lg px-4 py-2 text-white text-lg font-bold focus:outline-none focus:border-jeopardy-gold"
               />
+              {gameId && (
+                <div className="flex-shrink-0">
+                  <MediaUpload
+                    gameId={gameId}
+                    media={cat.media}
+                    label="+ Imagem do Header"
+                    onUpload={(asset) => updateCategory(selectedCat, { media: asset })}
+                    onRemove={() => updateCategory(selectedCat, { media: undefined })}
+                  />
+                </div>
+              )}
               {game.categories.length > 1 && (
                 <button
                   className="text-red-400 hover:text-red-300 text-sm px-3 py-2 border border-red-400 rounded-lg"
@@ -181,7 +323,7 @@ export function EditorView() {
             <div className="flex flex-col gap-3">
               {cat.questions.map((q, qi) => (
                 <div key={q.id} className="card flex flex-col gap-3">
-                  <div className="flex items-center gap-3">
+                  <div className="flex items-center gap-3 flex-wrap">
                     <span className="text-jeopardy-gold font-bold">$</span>
                     <input
                       type="number"
@@ -196,7 +338,7 @@ export function EditorView() {
                     >
                       <option value="standard">Normal</option>
                       <option value="all_play">Todos Jogam</option>
-                      <option value="challenge">Desafie um Jogador</option>
+                      <option value="challenge">Desafio</option>
                       <option value="double">Dupla Aposta</option>
                     </select>
                     <input
@@ -210,6 +352,15 @@ export function EditorView() {
                       }
                       className="w-24 bg-jeopardy-blue border border-slate-600 rounded px-2 py-1 text-slate-300 text-sm text-center"
                     />
+                    {cat.questions.length > 1 && (
+                      <button
+                        type="button"
+                        className="ml-auto text-red-400 text-xs hover:text-red-300 border border-red-400 rounded px-2 py-1"
+                        onClick={() => removeQuestion(selectedCat, qi)}
+                      >
+                        Remover
+                      </button>
+                    )}
                   </div>
                   <textarea
                     placeholder="Clue (o que aparece na tela)"
@@ -225,8 +376,62 @@ export function EditorView() {
                     onChange={(e) => updateQuestion(selectedCat, qi, { answer: e.target.value })}
                     className="w-full bg-jeopardy-blue border border-slate-600 rounded px-3 py-2 text-slate-400 focus:outline-none focus:border-jeopardy-gold"
                   />
+                  {q.type === 'challenge' && (
+                    <input
+                      type="text"
+                      placeholder="Dica do alvo (ex: jogador mais pontuado) — opcional"
+                      value={q.challengeTarget ?? ''}
+                      onChange={(e) => updateQuestion(selectedCat, qi, { challengeTarget: e.target.value || undefined })}
+                      className="w-full bg-jeopardy-blue border border-orange-500/40 rounded px-3 py-2 text-orange-300 text-sm focus:outline-none focus:border-orange-500"
+                    />
+                  )}
+                  {gameId && (
+                    <div className="grid grid-cols-2 gap-x-6 gap-y-2 mt-1">
+                      <div>
+                        <span className="text-slate-500 text-xs">Imagem do clue</span>
+                        <MediaUpload
+                          gameId={gameId} media={q.media} label="+ Imagem" accept="image/*"
+                          onUpload={(asset) => updateQuestion(selectedCat, qi, { media: asset })}
+                          onRemove={() => updateQuestion(selectedCat, qi, { media: undefined })}
+                        />
+                      </div>
+                      <div>
+                        <span className="text-slate-500 text-xs">Áudio do clue</span>
+                        <MediaUpload
+                          gameId={gameId} media={q.clueAudio} label="+ Áudio" accept="audio/*"
+                          onUpload={(asset) => updateQuestion(selectedCat, qi, { clueAudio: asset })}
+                          onRemove={() => updateQuestion(selectedCat, qi, { clueAudio: undefined })}
+                        />
+                      </div>
+                      <div>
+                        <span className="text-slate-500 text-xs">Imagem da resposta</span>
+                        <MediaUpload
+                          gameId={gameId} media={q.answerMedia} label="+ Imagem" accept="image/*"
+                          onUpload={(asset) => updateQuestion(selectedCat, qi, { answerMedia: asset })}
+                          onRemove={() => updateQuestion(selectedCat, qi, { answerMedia: undefined })}
+                        />
+                      </div>
+                      <div>
+                        <span className="text-slate-500 text-xs">Áudio da resposta</span>
+                        <MediaUpload
+                          gameId={gameId} media={q.answerAudio} label="+ Áudio" accept="audio/*"
+                          onUpload={(asset) => updateQuestion(selectedCat, qi, { answerAudio: asset })}
+                          onRemove={() => updateQuestion(selectedCat, qi, { answerAudio: undefined })}
+                        />
+                      </div>
+                    </div>
+                  )}
                 </div>
               ))}
+              {cat.questions.length < 10 && (
+                <button
+                  type="button"
+                  className="btn-ghost text-sm py-2 mt-1"
+                  onClick={() => addQuestion(selectedCat)}
+                >
+                  + Questão
+                </button>
+              )}
             </div>
 
             {/* Configurações do Desafio Final */}
@@ -255,8 +460,16 @@ export function EditorView() {
                     placeholder="Resposta do Desafio Final"
                     value={game.finalChallengeAnswer}
                     onChange={(e) => setGame((g) => ({ ...g, finalChallengeAnswer: e.target.value }))}
-                    className="w-full bg-jeopardy-blue border border-slate-600 rounded px-3 py-2 text-slate-400 focus:outline-none focus:border-jeopardy-gold"
+                    className="w-full bg-jeopardy-blue border border-slate-600 rounded px-3 py-2 text-slate-400 focus:outline-none focus:border-jeopardy-gold mb-2"
                   />
+                  {gameId && (
+                    <MediaUpload
+                      gameId={gameId}
+                      media={game.finalChallengeMedia}
+                      onUpload={(asset) => setGame((g) => ({ ...g, finalChallengeMedia: asset }))}
+                      onRemove={() => setGame((g) => ({ ...g, finalChallengeMedia: undefined }))}
+                    />
+                  )}
                 </>
               )}
             </div>

--- a/packages/client/src/views/host/HostBoardView.tsx
+++ b/packages/client/src/views/host/HostBoardView.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useState, useCallback, useRef } from 'react';
 import { useParams, useNavigate } from 'react-router-dom';
 import { motion, AnimatePresence } from 'framer-motion';
 import { socket } from '../../socket.js';
@@ -16,11 +16,29 @@ export function HostBoardView() {
     gameConfig, players, phase, activeQuestion,
     buzzerQueue, timer, hostToken,
     finalClue, finalCorrectAnswer, wagersSubmitted, hostWagers, revealedWagers,
+    doublePlayerId, doublePlayerName, challengeState,
   } = useGameStore();
   useSocketEvents();
 
   const [showEndConfirm, setShowEndConfirm] = useState(false);
   const [showLeaveConfirm, setShowLeaveConfirm] = useState(false);
+
+  const audioRef = useRef<HTMLAudioElement | null>(null);
+  // Ignora null: evita que a exit animation do AnimatePresence sobrescreva o ref
+  // com null depois do novo overlay já ter registrado o elemento correto.
+  const audioCallbackRef = useCallback((el: HTMLAudioElement | null) => {
+    if (el !== null) audioRef.current = el;
+  }, []);
+
+  function emitAudio(action: 'play' | 'pause' | 'seek') {
+    if (!audioRef.current || !sessionId || !hostToken) return;
+    socket.emit('host:audioControl', {
+      sessionId,
+      hostToken,
+      action,
+      currentTime: audioRef.current.currentTime,
+    });
+  }
 
   if (!gameConfig || !sessionId || !hostToken) return null;
 
@@ -40,6 +58,15 @@ export function HostBoardView() {
   }
   function timerControl(action: 'pause' | 'resume' | 'extend' | 'set', seconds?: number) {
     socket.emit('host:timerControl', { sessionId: sessionId!, hostToken: hostToken!, action, seconds });
+  }
+  function continueBoard() {
+    socket.emit('host:continueBoard', { sessionId: sessionId!, hostToken: hostToken! });
+  }
+  function assignDouble(playerId: string) {
+    socket.emit('host:assignDouble', { sessionId: sessionId!, hostToken: hostToken!, playerId });
+  }
+  function setChallenge(challengedId: string) {
+    socket.emit('host:setChallenge', { sessionId: sessionId!, hostToken: hostToken!, challengedId });
   }
   function revealFinal(playerId: string, isCorrect: boolean) {
     socket.emit('host:revealFinal', { sessionId: sessionId!, hostToken: hostToken!, playerId, isCorrect });
@@ -91,6 +118,7 @@ export function HostBoardView() {
         <div className="flex-1">
           <GameBoard
             categories={gameConfig.categories}
+            gameId={gameConfig.id}
             onSelectQuestion={phase === 'board' ? selectQuestion : undefined}
             activeQuestionId={activeQuestion?.questionId}
           />
@@ -102,7 +130,7 @@ export function HostBoardView() {
 
           {/* Timer + controles */}
           <AnimatePresence>
-            {(phase === 'question' || phase === 'buzzer_queue') && activeQuestion && (
+            {(phase === 'question' || phase === 'all_play' || phase === 'buzzer_queue') && activeQuestion && (
               <motion.div
                 initial={{ opacity: 0, y: 10 }}
                 animate={{ opacity: 1, y: 0 }}
@@ -132,29 +160,79 @@ export function HostBoardView() {
 
           {/* Fila de buzzers */}
           <AnimatePresence>
-            {phase === 'buzzer_queue' && pendingBuzzers.length > 0 && (
+            {phase === 'buzzer_queue' && (pendingBuzzers.length > 0 || challengeState?.challengedId) && (
               <motion.div
                 initial={{ opacity: 0, y: 10 }}
                 animate={{ opacity: 1, y: 0 }}
                 exit={{ opacity: 0 }}
                 className="card flex flex-col gap-3"
               >
-                <h3 className="text-jeopardy-gold font-bold text-sm">Fila de Respostas</h3>
-                {pendingBuzzers.map((entry, i) => (
-                  <div key={entry.playerId} className="flex flex-col gap-2 border-b border-slate-600 pb-2">
-                    <div className="flex items-center gap-2">
-                      <span className="text-slate-400 text-xs">#{i + 1}</span>
-                      <span className="font-bold flex-1">{entry.playerName}</span>
-                    </div>
-                    {i === 0 && (
-                      <div className="flex gap-2">
-                        <button className="flex-1 bg-green-600 hover:bg-green-500 text-white font-bold py-2 rounded text-sm" onClick={() => judge(entry.playerId, true)}>Correto</button>
-                        <button className="flex-1 bg-red-600 hover:bg-red-500 text-white font-bold py-2 rounded text-sm" onClick={() => judge(entry.playerId, false)}>Errado</button>
-                        <button className="bg-gray-600 hover:bg-gray-500 text-white font-bold py-2 px-3 rounded text-sm" onClick={() => skipPlayer(entry.playerId)}>Pular</button>
-                      </div>
+                {activeQuestion?.question.type === 'challenge' ? (
+                  // UI especial para challenge
+                  <>
+                    <h3 className="text-jeopardy-gold font-bold text-sm">⚔️ Desafio</h3>
+                    {!challengeState?.challengedId ? (
+                      // Passo 1: desafiador buzzou, selecionar desafiado
+                      <>
+                        <p className="text-sm text-white font-bold">
+                          {pendingBuzzers[0]?.playerName} desafia quem?
+                        </p>
+                        <div className="flex flex-col gap-1">
+                          {players
+                            .filter((p) => p.id !== pendingBuzzers[0]?.playerId)
+                            .map((p) => (
+                              <button
+                                key={p.id}
+                                className="text-left py-1 px-2 rounded bg-slate-700 hover:bg-jeopardy-gold hover:text-jeopardy-blue text-sm font-bold transition-colors"
+                                onClick={() => setChallenge(p.id)}
+                              >
+                                {p.name}
+                              </button>
+                            ))}
+                        </div>
+                        <button className="btn-ghost text-xs py-1" onClick={() => skipPlayer(pendingBuzzers[0]?.playerId)}>Pular</button>
+                      </>
+                    ) : (
+                      // Passo 2: desafiado definido, julgar
+                      <>
+                        <p className="text-xs text-slate-400">
+                          <span className="text-white font-bold">{challengeState.challengerName}</span> desafia{' '}
+                          <span className="text-jeopardy-gold font-bold">{challengeState.challengedName}</span>
+                        </p>
+                        <p className="text-xs text-slate-500">
+                          Certo: {challengeState.challengedName} +${activeQuestion.question.value}, {challengeState.challengerName} -${Math.floor(activeQuestion.question.value / 2)}
+                        </p>
+                        <p className="text-xs text-slate-500">
+                          Errado: {challengeState.challengedName} -${activeQuestion.question.value}, {challengeState.challengerName} +${Math.floor(activeQuestion.question.value / 2)}
+                        </p>
+                        <div className="flex gap-2 mt-1">
+                          <button className="flex-1 bg-green-600 hover:bg-green-500 text-white font-bold py-2 rounded text-sm" onClick={() => judge(challengeState.challengedId!, true)}>Correto</button>
+                          <button className="flex-1 bg-red-600 hover:bg-red-500 text-white font-bold py-2 rounded text-sm" onClick={() => judge(challengeState.challengedId!, false)}>Errado</button>
+                        </div>
+                      </>
                     )}
-                  </div>
-                ))}
+                  </>
+                ) : (
+                  // UI padrão de fila
+                  <>
+                    <h3 className="text-jeopardy-gold font-bold text-sm">Fila de Respostas</h3>
+                    {pendingBuzzers.map((entry, i) => (
+                      <div key={entry.playerId} className="flex flex-col gap-2 border-b border-slate-600 pb-2">
+                        <div className="flex items-center gap-2">
+                          <span className="text-slate-400 text-xs">#{i + 1}</span>
+                          <span className="font-bold flex-1">{entry.playerName}</span>
+                        </div>
+                        {i === 0 && (
+                          <div className="flex gap-2">
+                            <button className="flex-1 bg-green-600 hover:bg-green-500 text-white font-bold py-2 rounded text-sm" onClick={() => judge(entry.playerId, true)}>Correto</button>
+                            <button className="flex-1 bg-red-600 hover:bg-red-500 text-white font-bold py-2 rounded text-sm" onClick={() => judge(entry.playerId, false)}>Errado</button>
+                            <button className="bg-gray-600 hover:bg-gray-500 text-white font-bold py-2 px-3 rounded text-sm" onClick={() => skipPlayer(entry.playerId)}>Pular</button>
+                          </div>
+                        )}
+                      </div>
+                    ))}
+                  </>
+                )}
               </motion.div>
             )}
           </AnimatePresence>
@@ -163,7 +241,7 @@ export function HostBoardView() {
 
       {/* Overlay da questão ativa */}
       <AnimatePresence>
-        {activeQuestion && phase === 'question' && pendingBuzzers.length === 0 && (
+        {activeQuestion && (phase === 'question' || phase === 'all_play') && pendingBuzzers.length === 0 && (
           <motion.div
             initial={{ opacity: 0 }}
             animate={{ opacity: 1 }}
@@ -173,10 +251,30 @@ export function HostBoardView() {
             <div className="max-w-3xl w-full text-center">
               <div className="text-jeopardy-gold text-2xl mb-4">${activeQuestion.question.value}</div>
               {activeQuestion.question.media && (
-                <img src={`/media/${activeQuestion.question.media.filename}`} alt="" className="mx-auto max-h-64 object-contain mb-6 rounded-xl" />
+                <img src={`/media/${gameConfig.id}/${activeQuestion.question.media.filename}`} alt="" className="mx-auto max-h-56 object-contain mb-4 rounded-xl" />
+              )}
+              {activeQuestion.question.clueAudio && (
+                <audio
+                  key={activeQuestion.question.clueAudio.filename}
+                  ref={audioCallbackRef}
+                  src={`/media/${gameConfig.id}/${activeQuestion.question.clueAudio.filename}`}
+                  controls autoPlay className="mx-auto mb-4"
+                  onPlay={() => emitAudio('play')}
+                  onPause={() => emitAudio('pause')}
+                  onSeeked={() => emitAudio(audioRef.current?.paused ? 'seek' : 'play')}
+                />
               )}
               <p className="text-4xl font-bold leading-tight mb-8">{activeQuestion.question.clue}</p>
-              <p className="text-slate-400 italic mb-6 text-lg">{activeQuestion.question.answer}</p>
+              <p className="text-slate-400 italic mb-4 text-lg">{activeQuestion.question.answer}</p>
+              {activeQuestion.question.answerMedia && (
+                <img src={`/media/${gameConfig.id}/${activeQuestion.question.answerMedia.filename}`} alt="" className="mx-auto max-h-40 object-contain mb-3 rounded-xl opacity-80 border-2 border-jeopardy-gold/40" />
+              )}
+              {activeQuestion.question.answerAudio && (
+                <audio
+                  src={`/media/${gameConfig.id}/${activeQuestion.question.answerAudio.filename}`}
+                  controls className="mx-auto mb-4"
+                />
+              )}
               {timer && (
                 <div className="max-w-md mx-auto mb-6">
                   <QuestionTimer remainingMs={timer.remainingMs} totalMs={timer.totalMs} isPaused={timer.isPaused} />
@@ -190,6 +288,117 @@ export function HostBoardView() {
                 <button className="btn-ghost" onClick={() => timerControl('extend', 30)}>+30s</button>
                 <button className="btn-ghost text-red-400 border-red-400" onClick={clearQuestion}>Fechar</button>
               </div>
+            </div>
+          </motion.div>
+        )}
+      </AnimatePresence>
+
+      {/* Overlay da Dupla Aposta */}
+      <AnimatePresence>
+        {phase === 'double_wager' && activeQuestion && (
+          <motion.div
+            initial={{ opacity: 0 }}
+            animate={{ opacity: 1 }}
+            exit={{ opacity: 0 }}
+            className="fixed inset-0 bg-jeopardy-blue flex items-center justify-center p-8 z-50"
+          >
+            <div className="max-w-2xl w-full text-center flex flex-col items-center gap-6">
+              <div className="text-6xl">🎯</div>
+              <h2 className="text-4xl font-bold text-jeopardy-gold">DUPLA APOSTA!</h2>
+              <div className="text-jeopardy-gold text-xl">${activeQuestion.question.value} · {activeQuestion.question.clue}</div>
+              <p className="text-slate-400 italic text-sm">{activeQuestion.question.answer}</p>
+
+              {!doublePlayerId ? (
+                <div className="w-full">
+                  <p className="text-slate-300 mb-4">Atribuir a qual jogador?</p>
+                  <div className="flex flex-col gap-2">
+                    {players.map((p) => (
+                      <button
+                        key={p.id}
+                        className="flex items-center gap-3 p-3 rounded-xl bg-slate-800/50 hover:bg-jeopardy-gold hover:text-jeopardy-blue transition-colors font-bold"
+                        onClick={() => assignDouble(p.id)}
+                      >
+                        <div className="w-4 h-4 rounded-full flex-shrink-0" style={{ backgroundColor: p.avatarColor }} />
+                        <span className="flex-1 text-left">{p.name}</span>
+                        <span className="text-sm opacity-60">${p.score.toLocaleString('pt-BR')}</span>
+                      </button>
+                    ))}
+                  </div>
+                </div>
+              ) : (
+                <div className="text-center">
+                  <p className="text-2xl font-bold text-white">{doublePlayerName}</p>
+                  <p className="text-slate-400 mt-2 animate-pulse">Aguardando aposta...</p>
+                </div>
+              )}
+
+              <button className="btn-ghost text-sm" onClick={clearQuestion}>Cancelar</button>
+            </div>
+          </motion.div>
+        )}
+      </AnimatePresence>
+
+      {/* Overlay de revelação da resposta */}
+      <AnimatePresence>
+        {phase === 'answer_reveal' && activeQuestion && (
+          <motion.div
+            initial={{ opacity: 0 }}
+            animate={{ opacity: 1 }}
+            exit={{ opacity: 0 }}
+            className="fixed inset-0 bg-jeopardy-blue flex items-center justify-center p-8 z-50"
+          >
+            <div className="max-w-3xl w-full text-center flex flex-col items-center gap-6">
+              <div className="text-jeopardy-gold text-2xl">${activeQuestion.question.value}</div>
+
+              {/* Clue (referência) */}
+              {activeQuestion.question.media && (
+                <img src={`/media/${gameConfig.id}/${activeQuestion.question.media.filename}`} alt="" className="max-h-32 object-contain rounded-xl opacity-60" />
+              )}
+              {activeQuestion.question.clueAudio && (
+                activeQuestion.question.answerAudio
+                  // Quando há answerAudio, o clue audio é só referência visual — sem sync
+                  ? <audio
+                      src={`/media/${gameConfig.id}/${activeQuestion.question.clueAudio.filename}`}
+                      controls
+                      className="mx-auto opacity-40 pointer-events-none"
+                    />
+                  // Quando só existe clueAudio, ele é o áudio principal — sincroniza
+                  : <audio
+                      ref={audioCallbackRef}
+                      src={`/media/${gameConfig.id}/${activeQuestion.question.clueAudio.filename}`}
+                      controls className="mx-auto opacity-60"
+                      onPlay={() => emitAudio('play')}
+                      onPause={() => emitAudio('pause')}
+                      onSeeked={() => emitAudio(audioRef.current?.paused ? 'seek' : 'play')}
+                    />
+              )}
+
+              <p className="text-slate-400 text-xl italic">{activeQuestion.question.clue}</p>
+
+              <div className="border-t border-jeopardy-gold/30 pt-6 w-full">
+                <p className="text-slate-400 text-sm uppercase tracking-widest mb-2">Resposta</p>
+                <p className="text-4xl font-bold text-jeopardy-gold leading-tight">{activeQuestion.question.answer}</p>
+              </div>
+
+              {/* Mídia da resposta */}
+              {activeQuestion.question.answerMedia && (
+                <img src={`/media/${gameConfig.id}/${activeQuestion.question.answerMedia.filename}`} alt="" className="max-h-56 object-contain rounded-xl border-2 border-jeopardy-gold/40" />
+              )}
+              {activeQuestion.question.answerAudio && (
+                <audio
+                  key={activeQuestion.question.answerAudio.filename}
+                  ref={audioCallbackRef}
+                  src={`/media/${gameConfig.id}/${activeQuestion.question.answerAudio.filename}`}
+                  controls autoPlay className="mx-auto"
+                  onPlay={() => emitAudio('play')}
+                  onPause={() => emitAudio('pause')}
+                  onSeeked={() => emitAudio(audioRef.current?.paused ? 'seek' : 'play')}
+                />
+              )}
+
+              <button className="btn-primary text-xl px-10 py-3 mt-2" onClick={continueBoard}>
+                Continuar →
+              </button>
             </div>
           </motion.div>
         )}

--- a/packages/client/src/views/player/PlayerGameView.tsx
+++ b/packages/client/src/views/player/PlayerGameView.tsx
@@ -105,7 +105,7 @@ export function PlayerGameView() {
   }
 
   const isDoubleAndNotAssigned = activeQuestion?.question.type === 'double' && doublePlayerId && doublePlayerId !== myId;
-  const canBuzz = (phase === 'question' || phase === 'all_play') && !buzzerPosition && !isDoubleAndNotAssigned;
+  const canBuzz = (phase === 'question' || phase === 'all_play' || phase === 'buzzer_queue') && !buzzerPosition && !isDoubleAndNotAssigned;
 
   return (
     <div className="min-h-screen flex flex-col p-4 gap-4">
@@ -151,14 +151,19 @@ export function PlayerGameView() {
                 <input
                   type="number"
                   min={0}
-                  max={Math.max(myPlayer?.score ?? 0, 0)}
+                  max={Math.max(myPlayer?.score ?? 0, activeQuestion.question.value)}
                   value={doubleWagerInput}
                   onChange={(e) => setDoubleWagerInput(e.target.value)}
                   className="w-full bg-jeopardy-blue-light border-2 border-jeopardy-gold rounded-lg px-4 py-3 text-jeopardy-gold text-2xl text-center font-bold focus:outline-none"
                   placeholder="0"
                   autoFocus
                 />
-                <p className="text-slate-400 text-xs text-center">Máx: ${Math.max(myPlayer?.score ?? 0, 0).toLocaleString('pt-BR')}</p>
+                <p className="text-slate-400 text-xs text-center">
+                  Máx: ${Math.max(myPlayer?.score ?? 0, activeQuestion.question.value).toLocaleString('pt-BR')}
+                  {(myPlayer?.score ?? 0) < 0 && (
+                    <span className="text-orange-400 ml-1">(valor da questão — saldo negativo)</span>
+                  )}
+                </p>
                 <button type="submit" className="btn-primary text-xl">Confirmar Aposta</button>
               </form>
             ) : (
@@ -231,7 +236,7 @@ export function PlayerGameView() {
             )}
 
             {/* Buzzer */}
-            {(phase === 'question' || phase === 'all_play') && !isDoubleAndNotAssigned && (
+            {(phase === 'question' || phase === 'all_play' || phase === 'buzzer_queue') && !isDoubleAndNotAssigned && (
               <motion.button
                 whileTap={{ scale: 0.92 }}
                 className={`w-40 h-40 rounded-full font-bold text-2xl border-8 transition-all ${

--- a/packages/client/src/views/player/PlayerGameView.tsx
+++ b/packages/client/src/views/player/PlayerGameView.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useState, useRef, useCallback, useEffect } from 'react';
 import { useParams, useNavigate } from 'react-router-dom';
 import { motion, AnimatePresence } from 'framer-motion';
 import { socket } from '../../socket.js';
@@ -20,12 +20,37 @@ export function PlayerGameView() {
     timer,
     myWagerSent,
     finalClue,
+    finalMedia,
     setMyWagerSent,
+    doublePlayerId,
+    doublePlayerName,
+    doubleWager,
+    challengeState,
   } = useGameStore();
   const { myId, myName, buzzerPosition } = usePlayerStore();
   const [wagerAmount, setWagerAmount] = useState('');
   const [wagerAnswer, setWagerAnswer] = useState('');
+  const [doubleWagerInput, setDoubleWagerInput] = useState('');
+  const [doubleWagerSent, setDoubleWagerSent] = useState(false);
+  const audioRef = useRef<HTMLAudioElement | null>(null);
+  // Callback ref que ignora null: evita que a exit animation do AnimatePresence
+  // sobrescreva o ref com null depois do novo elemento já ter sido registrado.
+  const audioCallbackRef = useCallback((el: HTMLAudioElement | null) => {
+    if (el !== null) audioRef.current = el;
+  }, []);
   useSocketEvents();
+
+  useEffect(() => {
+    function handleAudioSync({ action, currentTime }: { action: 'play' | 'pause' | 'seek'; currentTime: number }) {
+      const el = audioRef.current;
+      if (!el) return;
+      el.currentTime = currentTime;
+      if (action === 'play') el.play().catch(() => {});
+      else if (action === 'pause') el.pause();
+    }
+    socket.on('audio:sync', handleAudioSync);
+    return () => { socket.off('audio:sync', handleAudioSync); };
+  }, []);
 
   const myPlayer = players.find((p) => p.id === myId);
 
@@ -40,6 +65,14 @@ export function PlayerGameView() {
     const amount = Math.max(0, parseInt(wagerAmount) || 0);
     socket.emit('player:finalWager', { sessionId, playerId: myId, amount, answer: wagerAnswer });
     setMyWagerSent();
+  }
+
+  function submitDoubleWager(e: React.FormEvent) {
+    e.preventDefault();
+    if (!sessionId || !myId) return;
+    const amount = Math.max(0, parseInt(doubleWagerInput) || 0);
+    socket.emit('player:doubleWager', { sessionId, playerId: myId, amount });
+    setDoubleWagerSent(true);
   }
 
   if (!gameConfig) {
@@ -71,7 +104,8 @@ export function PlayerGameView() {
     );
   }
 
-  const canBuzz = (phase === 'question' || phase === 'all_play') && !buzzerPosition;
+  const isDoubleAndNotAssigned = activeQuestion?.question.type === 'double' && doublePlayerId && doublePlayerId !== myId;
+  const canBuzz = (phase === 'question' || phase === 'all_play') && !buzzerPosition && !isDoubleAndNotAssigned;
 
   return (
     <div className="min-h-screen flex flex-col p-4 gap-4">
@@ -87,11 +121,12 @@ export function PlayerGameView() {
       </div>
 
       {/* Board (somente leitura) */}
-      {(phase === 'board' || phase === 'question' || phase === 'buzzer_queue') && (
+      {(phase === 'board' || phase === 'question' || phase === 'all_play' || phase === 'buzzer_queue') && (
         <div className="flex gap-4">
           <div className="flex-1">
             <GameBoard
               categories={gameConfig.categories}
+              gameId={gameConfig.id}
               activeQuestionId={activeQuestion?.questionId}
             />
           </div>
@@ -101,9 +136,50 @@ export function PlayerGameView() {
         </div>
       )}
 
+      {/* Dupla Aposta */}
+      {phase === 'double_wager' && activeQuestion && (
+        <div className="fixed inset-0 bg-jeopardy-blue flex flex-col items-center justify-center p-6 z-50 gap-6">
+          <div className="text-6xl">🎯</div>
+          <h2 className="text-4xl font-bold text-jeopardy-gold">DUPLA APOSTA!</h2>
+          <p className="text-jeopardy-gold text-xl">${activeQuestion.question.value}</p>
+
+          {doublePlayerId === myId ? (
+            // Sou o jogador atribuído
+            !doubleWagerSent ? (
+              <form onSubmit={submitDoubleWager} className="flex flex-col gap-4 w-full max-w-md">
+                <p className="text-center text-slate-300">Você foi selecionado! Faça sua aposta antes de ver a pergunta.</p>
+                <input
+                  type="number"
+                  min={0}
+                  max={Math.max(myPlayer?.score ?? 0, 0)}
+                  value={doubleWagerInput}
+                  onChange={(e) => setDoubleWagerInput(e.target.value)}
+                  className="w-full bg-jeopardy-blue-light border-2 border-jeopardy-gold rounded-lg px-4 py-3 text-jeopardy-gold text-2xl text-center font-bold focus:outline-none"
+                  placeholder="0"
+                  autoFocus
+                />
+                <p className="text-slate-400 text-xs text-center">Máx: ${Math.max(myPlayer?.score ?? 0, 0).toLocaleString('pt-BR')}</p>
+                <button type="submit" className="btn-primary text-xl">Confirmar Aposta</button>
+              </form>
+            ) : (
+              <p className="text-slate-300 animate-pulse">Aposta enviada! Aguardando o host...</p>
+            )
+          ) : doublePlayerId ? (
+            // Outro jogador foi selecionado
+            <div className="text-center text-slate-300">
+              <p className="text-xl font-bold text-white">{doublePlayerName}</p>
+              <p className="text-slate-400 mt-2 animate-pulse">está fazendo sua aposta...</p>
+            </div>
+          ) : (
+            // Aguardando host atribuir
+            <p className="text-slate-400 animate-pulse">Aguardando o host atribuir a um jogador...</p>
+          )}
+        </div>
+      )}
+
       {/* Questão ativa — overlay para player */}
       <AnimatePresence>
-        {activeQuestion && (phase === 'question' || phase === 'buzzer_queue') && (
+        {activeQuestion && (phase === 'question' || phase === 'all_play' || phase === 'buzzer_queue') && (
           <motion.div
             initial={{ opacity: 0 }}
             animate={{ opacity: 1 }}
@@ -112,13 +188,31 @@ export function PlayerGameView() {
           >
             <div className="text-jeopardy-gold text-xl">
               ${activeQuestion.question.value}
+              {phase === 'all_play' && <span className="ml-3 text-sm bg-yellow-500 text-black px-2 py-0.5 rounded font-bold">TODOS JOGAM</span>}
+              {activeQuestion.question.type === 'double' && doubleWager !== null && <span className="ml-3 text-sm bg-purple-500 text-white px-2 py-0.5 rounded font-bold">DUPLA APOSTA ${doubleWager}</span>}
             </div>
+
+            {/* Notificação de challenge */}
+            {challengeState?.challengedId === myId && (
+              <div className="bg-orange-600 text-white px-4 py-2 rounded-xl font-bold text-lg">
+                ⚔️ Você foi desafiado por {challengeState.challengerName}!
+              </div>
+            )}
 
             {activeQuestion.question.media && (
               <img
-                src={`/media/${activeQuestion.question.media.filename}`}
+                src={`/media/${gameConfig.id}/${activeQuestion.question.media.filename}`}
                 alt=""
                 className="max-h-48 object-contain rounded-xl"
+              />
+            )}
+
+            {activeQuestion.question.clueAudio && (
+              <audio
+                key={activeQuestion.question.clueAudio.filename}
+                ref={audioCallbackRef}
+                src={`/media/${gameConfig.id}/${activeQuestion.question.clueAudio.filename}`}
+                autoPlay
               />
             )}
 
@@ -137,7 +231,7 @@ export function PlayerGameView() {
             )}
 
             {/* Buzzer */}
-            {phase === 'question' && (
+            {(phase === 'question' || phase === 'all_play') && !isDoubleAndNotAssigned && (
               <motion.button
                 whileTap={{ scale: 0.92 }}
                 className={`w-40 h-40 rounded-full font-bold text-2xl border-8 transition-all ${
@@ -167,12 +261,72 @@ export function PlayerGameView() {
         )}
       </AnimatePresence>
 
+      {/* Revelação da resposta */}
+      {phase === 'answer_reveal' && activeQuestion && (
+        <motion.div
+          initial={{ opacity: 0 }}
+          animate={{ opacity: 1 }}
+          className="fixed inset-0 bg-jeopardy-blue flex flex-col items-center justify-center p-8 z-50 gap-6 text-center"
+        >
+          <div className="text-jeopardy-gold text-xl">${activeQuestion.question.value}</div>
+
+          {/* Clue reference (dimmed) */}
+          {activeQuestion.question.media && (
+            <img
+              src={`/media/${gameConfig.id}/${activeQuestion.question.media.filename}`}
+              alt=""
+              className="max-h-36 object-contain rounded-xl opacity-60"
+            />
+          )}
+          {/* Hidden clue audio for sync — only used when no answerAudio */}
+          {activeQuestion.question.clueAudio && !activeQuestion.question.answerAudio && (
+            <audio
+              key={activeQuestion.question.clueAudio.filename}
+              ref={audioCallbackRef}
+              src={`/media/${gameConfig.id}/${activeQuestion.question.clueAudio.filename}`}
+            />
+          )}
+
+          <p className="text-slate-400 text-lg italic max-w-xl">{activeQuestion.question.clue}</p>
+
+          <div className="border-t border-jeopardy-gold/30 pt-6 w-full max-w-xl">
+            <p className="text-slate-400 text-xs uppercase tracking-widest mb-2">Resposta</p>
+            <p className="text-4xl font-bold text-jeopardy-gold leading-tight">{activeQuestion.question.answer}</p>
+          </div>
+
+          {activeQuestion.question.answerMedia && (
+            <img
+              src={`/media/${gameConfig.id}/${activeQuestion.question.answerMedia.filename}`}
+              alt=""
+              className="max-h-56 object-contain rounded-xl border-2 border-jeopardy-gold/40"
+            />
+          )}
+          {activeQuestion.question.answerAudio && (
+            <audio
+              key={activeQuestion.question.answerAudio.filename}
+              ref={audioCallbackRef}
+              src={`/media/${gameConfig.id}/${activeQuestion.question.answerAudio.filename}`}
+              autoPlay
+            />
+          )}
+
+          <p className="text-slate-500 text-sm animate-pulse">Aguardando o host continuar...</p>
+        </motion.div>
+      )}
+
       {/* Desafio Final */}
       {phase === 'final_challenge' && (
         <div className="fixed inset-0 bg-jeopardy-blue flex flex-col items-center justify-center p-6 z-50 gap-6">
           <h2 className="text-4xl font-bold text-jeopardy-gold">Desafio Final!</h2>
           {finalClue && (
             <p className="text-2xl font-bold text-center max-w-xl">{finalClue}</p>
+          )}
+          {finalMedia && (
+            finalMedia.type === 'audio' ? (
+              <audio src={`/media/${gameConfig?.id}/${finalMedia.filename}`} autoPlay controls className="w-full max-w-md" />
+            ) : (
+              <img src={`/media/${gameConfig?.id}/${finalMedia.filename}`} alt="" className="max-h-48 object-contain rounded-xl" />
+            )
           )}
           {!myWagerSent ? (
             <form onSubmit={submitWager} className="flex flex-col gap-4 w-full max-w-md">

--- a/packages/server/.env.example
+++ b/packages/server/.env.example
@@ -1,0 +1,23 @@
+PORT=3000
+NODE_ENV=development
+
+# URL do cliente para CORS (dev: Vite, prod: domínio do servidor)
+CLIENT_URL=http://localhost:5173
+
+# Chave de assinatura de tokens — gerada automaticamente se omitida (não persiste entre restarts)
+# SECRET_KEY=
+
+# Limite de jogadores por sessão
+MAX_PLAYERS=10
+
+# Tamanho máximo de upload de mídia em MB
+MEDIA_MAX_MB=10
+
+# Tempo de vida de uma sessão inativa em horas
+SESSION_TTL_HOURS=4
+
+# Janela de reconexão do host em segundos antes de a sessão ser destruída
+HOST_GRACE_PERIOD_SECONDS=30
+
+# Timer padrão das questões em segundos (pode ser sobrescrito por questão no editor)
+DEFAULT_TIMER_SECONDS=60

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -6,8 +6,8 @@
   "main": "./dist/index.js",
   "scripts": {
     "build": "tsc",
-    "dev": "tsx watch src/index.ts",
-    "start": "node dist/index.js",
+    "dev": "tsx watch --env-file .env src/index.ts",
+    "start": "node --env-file .env dist/index.js",
     "type-check": "tsc --noEmit",
     "clean": "rm -rf dist"
   },

--- a/packages/server/src/config.ts
+++ b/packages/server/src/config.ts
@@ -5,14 +5,15 @@ import { fileURLToPath } from 'url';
 const __dirname = dirname(fileURLToPath(import.meta.url));
 
 export const PORT = Number(process.env.PORT ?? 3000);
-export const CLIENT_URL = process.env.CLIENT_URL ?? `http://localhost:5173`;
+export const NODE_ENV = process.env.NODE_ENV ?? 'development';
+export const CLIENT_URL = process.env.CLIENT_URL ?? 'http://localhost:5173';
 export const DATA_DIR = resolve(__dirname, '../../..', 'data');
 export const GAMES_DIR = resolve(DATA_DIR, 'games');
 
-// Secret gerado em runtime — não persiste entre reinicializações (intencional para MVP)
 export const RUNTIME_SECRET = process.env.SECRET_KEY ?? randomBytes(32).toString('hex');
 
-export const SESSION_TTL_MS = 4 * 60 * 60 * 1000; // 4 horas
-export const HOST_GRACE_PERIOD_MS = 30 * 1000;     // 30 segundos
-export const MAX_PLAYERS = 10;
-export const DEFAULT_TIMER_MS = 60_000;
+export const SESSION_TTL_MS = Number(process.env.SESSION_TTL_HOURS ?? 4) * 60 * 60 * 1000;
+export const HOST_GRACE_PERIOD_MS = Number(process.env.HOST_GRACE_PERIOD_SECONDS ?? 30) * 1000;
+export const MAX_PLAYERS = Number(process.env.MAX_PLAYERS ?? 10);
+export const DEFAULT_TIMER_MS = Number(process.env.DEFAULT_TIMER_SECONDS ?? 60) * 1000;
+export const MEDIA_MAX_MB = Number(process.env.MEDIA_MAX_MB ?? 10);

--- a/packages/server/src/handlers/buzzerHandler.ts
+++ b/packages/server/src/handlers/buzzerHandler.ts
@@ -4,6 +4,7 @@ import { getSession, updateSession } from '../managers/sessionManager.js';
 import { validateHostToken } from '../middleware/authMiddleware.js';
 import { socketRateLimit } from '../middleware/rateLimiter.js';
 import { closeQuestion } from './gameHandler.js';
+import { startTimer } from '../managers/timerManager.js';
 
 function requireHost(
   socket: Socket,
@@ -43,6 +44,9 @@ export function registerBuzzerHandlers(
     const player = session.players[socket.id];
     if (!player) return;
 
+    // Dupla Aposta: só o jogador atribuído pode buzzar
+    if (session.activeQuestion?.question.type === 'double' && session.doublePlayerId && socket.id !== session.doublePlayerId) return;
+
     // Evitar duplicata na fila
     if (session.buzzerQueue.some((e) => e.playerId === socket.id)) return;
 
@@ -71,7 +75,7 @@ export function registerBuzzerHandlers(
     });
   });
 
-  // HOST: julgar resposta
+  // HOST: julgar resposta (standard, all_play, double, challenge)
   socket.on('host:judge', (payload) => {
     const session = requireHost(socket, payload.sessionId, payload.hostToken);
     if (!session) return;
@@ -81,63 +85,179 @@ export function registerBuzzerHandlers(
     const activeQuestion = session.activeQuestion;
     if (!activeQuestion) return;
 
-    const playerEntry = session.buzzerQueue.find(
-      (e) => e.playerId === payload.playerId && !e.responded,
-    );
-    if (!playerEntry) return;
+    const isChallenge = activeQuestion.question.type === 'challenge' &&
+      session.challengeState?.challengedId === payload.playerId;
+
+    // Para challenge, o jogador desafiado pode não estar na fila — bypass da verificação
+    if (!isChallenge) {
+      const playerEntry = session.buzzerQueue.find(
+        (e) => e.playerId === payload.playerId && !e.responded,
+      );
+      if (!playerEntry) return;
+    }
 
     const player = session.players[payload.playerId];
     if (!player) return;
 
-    const scoreChange = payload.correct ? activeQuestion.question.value : -activeQuestion.question.value;
-    const newScore = player.score + scoreChange;
-
-    // Atualizar score
     const updatedPlayers = { ...session.players };
-    updatedPlayers[payload.playerId] = { ...player, score: newScore };
 
-    // Marcar como respondido
+    let scoreChange: number;
+    let newScore: number;
+
+    if (isChallenge && session.challengeState) {
+      // Scoring especial de challenge
+      const challenger = session.players[session.challengeState.challengerId];
+      const value = activeQuestion.question.value;
+      if (payload.correct) {
+        // Desafiado acerta: +value; desafiador perde metade
+        scoreChange = value;
+        updatedPlayers[payload.playerId] = { ...player, score: player.score + value };
+        if (challenger) {
+          const challengerLoss = Math.floor(value / 2);
+          updatedPlayers[session.challengeState.challengerId] = {
+            ...challenger,
+            score: challenger.score - challengerLoss,
+          };
+        }
+      } else {
+        // Desafiado erra: -value; desafiador ganha metade
+        scoreChange = -value;
+        updatedPlayers[payload.playerId] = { ...player, score: player.score - value };
+        if (challenger) {
+          const challengerGain = Math.floor(value / 2);
+          updatedPlayers[session.challengeState.challengerId] = {
+            ...challenger,
+            score: challenger.score + challengerGain,
+          };
+        }
+      }
+      newScore = updatedPlayers[payload.playerId].score;
+    } else if (activeQuestion.question.type === 'double' && session.doubleWager !== null) {
+      // Scoring de Dupla Aposta: usa o valor apostado
+      scoreChange = payload.correct ? session.doubleWager : -session.doubleWager;
+      newScore = player.score + scoreChange;
+      updatedPlayers[payload.playerId] = { ...player, score: newScore };
+    } else {
+      // Scoring padrão
+      scoreChange = payload.correct ? activeQuestion.question.value : -activeQuestion.question.value;
+      newScore = player.score + scoreChange;
+      updatedPlayers[payload.playerId] = { ...player, score: newScore };
+    }
+
+    // Marcar como respondido na fila (se estiver)
     const updatedQueue = session.buzzerQueue.map((e) =>
       e.playerId === payload.playerId ? { ...e, responded: true } : e,
     );
 
-    const nextInQueue = updatedQueue.find((e) => !e.responded) ?? null;
-    const newPhase = nextInQueue ? 'buzzer_queue' : 'board';
+    const nextInQueue = isChallenge ? null : (updatedQueue.find((e) => !e.responded) ?? null);
+    const newPhase = payload.correct ? 'answer_reveal' : (nextInQueue ? 'buzzer_queue' : 'board');
 
     updateSession(payload.sessionId, {
-      phase: newPhase as 'buzzer_queue' | 'board',
+      phase: newPhase,
       players: updatedPlayers,
       buzzerQueue: updatedQueue,
     });
 
-    // Broadcast resultado do julgamento
     io.to(`session:${payload.sessionId}`).emit('judge:result', {
       playerId: payload.playerId,
       correct: payload.correct,
       scoreChange,
       newScore,
       nextInQueue,
-      phase: newPhase as 'buzzer_queue' | 'board',
+      phase: newPhase,
     });
 
-    // Broadcast scores atualizados
     io.to(`session:${payload.sessionId}`).emit('score:update', {
       players: Object.values(updatedPlayers),
     });
 
-    // Se correto, fechar questão marcando como usada
     if (payload.correct) {
       closeQuestion(io, payload.sessionId, true);
     } else if (!nextInQueue) {
-      // Fila esgotada e ninguém acertou
       closeQuestion(io, payload.sessionId, true);
     } else {
-      // Atualizar fila para o host
       io.to(`host:${payload.sessionId}`).emit('buzzer:queueUpdate', {
         queue: updatedQueue,
         phase: 'buzzer_queue',
       });
     }
+  });
+
+  // HOST: definir jogador desafiado (questão challenge)
+  socket.on('host:setChallenge', (payload) => {
+    const session = requireHost(socket, payload.sessionId, payload.hostToken);
+    if (!session || session.phase !== 'buzzer_queue') return;
+
+    const activeQuestion = session.activeQuestion;
+    if (!activeQuestion || activeQuestion.question.type !== 'challenge') return;
+
+    const challenged = session.players[payload.challengedId];
+    if (!challenged) {
+      socket.emit('error', { code: 'PLAYER_NOT_FOUND', message: 'Jogador não encontrado.' });
+      return;
+    }
+
+    // Challenger é o primeiro da fila que ainda não respondeu
+    const challenger = session.buzzerQueue.find((e) => !e.responded);
+    if (!challenger) return;
+
+    const challengeState = {
+      challengerId: challenger.playerId,
+      challengerName: challenger.playerName,
+      challengedId: payload.challengedId,
+      challengedName: challenged.name,
+    };
+
+    updateSession(payload.sessionId, { challengeState });
+
+    io.to(`session:${payload.sessionId}`).emit('challenge:assigned', { challengeState });
+  });
+
+  // PLAYER: enviar aposta da Dupla Aposta
+  socket.on('player:doubleWager', (payload) => {
+    const session = getSession(payload.sessionId);
+    if (!session || session.phase !== 'double_wager') return;
+
+    // Só o jogador atribuído pode apostar
+    if (session.doublePlayerId !== socket.id) return;
+    // Só uma aposta
+    if (session.doubleWager !== null) return;
+
+    const player = session.players[socket.id];
+    if (!player) return;
+
+    const maxWager = Math.max(player.score, 0);
+    const amount = Math.max(0, Math.min(payload.amount, maxWager));
+
+    const activeQuestion = session.activeQuestion;
+    if (!activeQuestion) return;
+
+    // Salva aposta e transita para question (clue revela para todos, timer inicia)
+    updateSession(payload.sessionId, {
+      phase: 'question',
+      doubleWager: amount,
+    });
+
+    // Avisa todos que a aposta foi feita e o clue vai ser revelado
+    io.to(`session:${payload.sessionId}`).emit('double:wagerLocked', {
+      assignedPlayerId: socket.id,
+      amount,
+    });
+
+    // Re-emite question:selected para revelar o clue (com phase=question)
+    io.to(`session:${payload.sessionId}`).emit('question:selected', {
+      activeQuestion,
+      phase: 'question',
+    });
+
+    // Inicia o timer
+    const timerMs = activeQuestion.timerDuration;
+    startTimer(io, payload.sessionId, timerMs, () => {
+      const current = getSession(payload.sessionId);
+      if (current?.phase === 'question') {
+        closeQuestion(io, payload.sessionId, false);
+      }
+    });
   });
 
   // HOST: pular player da fila

--- a/packages/server/src/handlers/buzzerHandler.ts
+++ b/packages/server/src/handlers/buzzerHandler.ts
@@ -39,7 +39,8 @@ export function registerBuzzerHandlers(
     const session = getSession(payload.sessionId);
     if (!session) return;
 
-    if (session.phase !== 'question' && session.phase !== 'all_play') return;
+    // Aceita buzz em question, all_play e buzzer_queue (para montar a fila completa)
+    if (session.phase !== 'question' && session.phase !== 'all_play' && session.phase !== 'buzzer_queue') return;
 
     const player = session.players[socket.id];
     if (!player) return;
@@ -226,11 +227,13 @@ export function registerBuzzerHandlers(
     const player = session.players[socket.id];
     if (!player) return;
 
-    const maxWager = Math.max(player.score, 0);
-    const amount = Math.max(0, Math.min(payload.amount, maxWager));
-
     const activeQuestion = session.activeQuestion;
     if (!activeQuestion) return;
+
+    // Saldo negativo: pode apostar até o valor da questão (chance de recuperar)
+    // Saldo positivo: pode apostar até o saldo atual
+    const maxWager = Math.max(player.score, activeQuestion.question.value);
+    const amount = Math.max(0, Math.min(payload.amount, maxWager));
 
     // Salva aposta e transita para question (clue revela para todos, timer inicia)
     updateSession(payload.sessionId, {

--- a/packages/server/src/handlers/gameHandler.ts
+++ b/packages/server/src/handlers/gameHandler.ts
@@ -85,30 +85,105 @@ export function registerGameHandlers(
       timerDuration: timerMs,
     };
 
-    updateSession(payload.sessionId, {
-      phase: 'question',
-      activeQuestion,
-      buzzerQueue: [],
-    });
+    if (question.type === 'double') {
+      // Dupla Aposta: vai para double_wager — timer não começa, aguarda host atribuir jogador
+      updateSession(payload.sessionId, {
+        phase: 'double_wager',
+        activeQuestion,
+        buzzerQueue: [],
+        doublePlayerId: null,
+        doubleWager: null,
+        challengeState: null,
+      });
+      io.to(`session:${payload.sessionId}`).emit('question:selected', {
+        activeQuestion,
+        phase: 'double_wager',
+      });
+      // Host vê aviso; host precisa atribuir um jogador via host:assignDouble
+      io.to(`host:${payload.sessionId}`).emit('double:started', {
+        assignedPlayerId: null,
+        assignedPlayerName: null,
+      });
+      return;
+    }
 
-    io.to(`session:${payload.sessionId}`).emit('question:selected', {
-      activeQuestion,
-      phase: 'question',
-    });
+    if (question.type === 'all_play') {
+      // Todos jogam: vai direto para all_play, timer começa
+      updateSession(payload.sessionId, {
+        phase: 'all_play',
+        activeQuestion,
+        buzzerQueue: [],
+        challengeState: null,
+      });
+      io.to(`session:${payload.sessionId}`).emit('question:selected', {
+        activeQuestion,
+        phase: 'all_play',
+      });
+    } else {
+      // Standard ou challenge: fase question normal
+      updateSession(payload.sessionId, {
+        phase: 'question',
+        activeQuestion,
+        buzzerQueue: [],
+        challengeState: null,
+      });
+      io.to(`session:${payload.sessionId}`).emit('question:selected', {
+        activeQuestion,
+        phase: 'question',
+      });
+    }
 
-    startTimer(io, payload.sessionId, timerMs, () => {
+    const onExpire = () => {
       const current = getSession(payload.sessionId);
-      if (current?.phase === 'question') {
+      if (current?.phase === 'question' || current?.phase === 'all_play') {
         closeQuestion(io, payload.sessionId, false);
       }
+    };
+
+    startTimer(io, payload.sessionId, timerMs, onExpire);
+  });
+
+  // HOST: atribuir jogador para Dupla Aposta
+  socket.on('host:assignDouble', (payload) => {
+    const session = requireHost(socket, payload.sessionId, payload.hostToken);
+    if (!session || session.phase !== 'double_wager') return;
+
+    const player = session.players[payload.playerId];
+    if (!player) {
+      socket.emit('error', { code: 'PLAYER_NOT_FOUND', message: 'Jogador não encontrado.' });
+      return;
+    }
+
+    updateSession(payload.sessionId, { doublePlayerId: payload.playerId });
+
+    io.to(`session:${payload.sessionId}`).emit('double:started', {
+      assignedPlayerId: player.id,
+      assignedPlayerName: player.name,
     });
   });
 
-  // HOST: limpar questão sem pontuar
+  // HOST: limpar questão sem pontuar (vai para answer_reveal)
   socket.on('host:clearQuestion', (payload) => {
     const session = requireHost(socket, payload.sessionId, payload.hostToken);
     if (!session) return;
     closeQuestion(io, payload.sessionId, false);
+  });
+
+  // HOST: controle de áudio — broadcast para todos exceto o host
+  socket.on('host:audioControl', (payload) => {
+    const session = requireHost(socket, payload.sessionId, payload.hostToken);
+    if (!session) return;
+    socket.to(`session:${payload.sessionId}`).emit('audio:sync', {
+      action: payload.action,
+      currentTime: payload.currentTime,
+    });
+  });
+
+  // HOST: avançar do answer_reveal para o board
+  socket.on('host:continueBoard', (payload) => {
+    const session = requireHost(socket, payload.sessionId, payload.hostToken);
+    if (!session || session.phase !== 'answer_reveal') return;
+    continueBoard(io, payload.sessionId);
   });
 
   // HOST: controle do timer
@@ -118,7 +193,7 @@ export function registerGameHandlers(
 
     const onExpire = () => {
       const current = getSession(payload.sessionId);
-      if (current?.phase === 'question') closeQuestion(io, payload.sessionId, false);
+      if (current?.phase === 'question' || current?.phase === 'all_play') closeQuestion(io, payload.sessionId, false);
     };
 
     switch (payload.action) {
@@ -194,15 +269,31 @@ export function closeQuestion(
 
   const updatedConfig = { ...session.gameConfig, categories: updatedCategories };
 
-  // Verificar se todas as questões foram usadas → Desafio Final
-  const allUsed = allQuestionsUsed(updatedCategories);
-  const nextPhase = allUsed && updatedConfig.finalChallengeEnabled ? 'final_challenge' : 'board';
+  // Ir para answer_reveal mantendo activeQuestion para exibição da resposta
+  updateSession(sessionId, {
+    phase: 'answer_reveal',
+    buzzerQueue: [],
+    gameConfig: updatedConfig,
+  });
+
+  io.to(`session:${sessionId}`).emit('question:answerReveal', { phase: 'answer_reveal' });
+}
+
+export function continueBoard(
+  io: Server<ClientToServerEvents, ServerToClientEvents>,
+  sessionId: string,
+): void {
+  const session = getSession(sessionId);
+  if (!session?.activeQuestion) return;
+
+  const { categoryId, questionId } = session.activeQuestion;
+  const allUsed = allQuestionsUsed(session.gameConfig.categories);
+  const nextPhase = allUsed && session.gameConfig.finalChallengeEnabled ? 'final_challenge' : 'board';
 
   updateSession(sessionId, {
     phase: nextPhase,
     activeQuestion: null,
     buzzerQueue: [],
-    gameConfig: updatedConfig,
   });
 
   io.to(`session:${sessionId}`).emit('question:closed', {

--- a/packages/server/src/handlers/lobbyHandler.ts
+++ b/packages/server/src/handlers/lobbyHandler.ts
@@ -59,6 +59,9 @@ export function registerLobbyHandlers(
       activeQuestion: null,
       buzzerQueue: [],
       finalChallengeWagers: {},
+      doublePlayerId: null,
+      doubleWager: null,
+      challengeState: null,
     });
 
     socket.join(`session:${sessionId}`);

--- a/packages/server/src/managers/gameStateManager.ts
+++ b/packages/server/src/managers/gameStateManager.ts
@@ -3,10 +3,12 @@ import type { GamePhase } from '@jeopardy/shared';
 // Transições válidas da state machine
 const VALID_TRANSITIONS: Record<GamePhase, GamePhase[]> = {
   lobby:            ['board'],
-  board:            ['question', 'final_challenge', 'game_over'],
-  question:         ['buzzer_queue', 'all_play', 'board'],
-  buzzer_queue:     ['buzzer_queue', 'board'],
-  all_play:         ['board'],
+  board:            ['question', 'all_play', 'double_wager', 'final_challenge', 'game_over'],
+  question:         ['buzzer_queue', 'answer_reveal', 'board'],
+  buzzer_queue:     ['buzzer_queue', 'answer_reveal', 'board'],
+  all_play:         ['buzzer_queue', 'answer_reveal', 'board'],
+  double_wager:     ['question'],
+  answer_reveal:    ['board', 'final_challenge'],
   final_challenge:  ['final_reveal'],
   final_reveal:     ['game_over'],
   game_over:        [],

--- a/packages/server/src/routes/gameRoutes.ts
+++ b/packages/server/src/routes/gameRoutes.ts
@@ -6,22 +6,27 @@ import type { GameConfig } from '@jeopardy/shared';
 
 export const gameRouter: IRouter = Router();
 
+const MediaAssetSchema = z.object({ type: z.enum(['image', 'audio']), filename: z.string(), altText: z.string().optional() });
+
 const QuestionSchema = z.object({
-  id: z.string().uuid(),
+  id: z.string().min(1),
   value: z.number().int().positive(),
   clue: z.string().min(1).max(2000),
   answer: z.string().min(1).max(500),
   type: z.enum(['standard', 'all_play', 'challenge', 'double']),
-  media: z.object({ type: z.enum(['image', 'audio']), filename: z.string(), altText: z.string().optional() }).optional(),
+  media: MediaAssetSchema.optional(),
+  clueAudio: MediaAssetSchema.optional(),
+  answerMedia: MediaAssetSchema.optional(),
+  answerAudio: MediaAssetSchema.optional(),
   used: z.boolean(),
   challengeTarget: z.string().optional(),
   timeOverride: z.number().int().positive().optional(),
 });
 
 const CategorySchema = z.object({
-  id: z.string().uuid(),
+  id: z.string().min(1),
   name: z.string().min(1).max(100),
-  media: z.object({ type: z.enum(['image', 'audio']), filename: z.string(), altText: z.string().optional() }).optional(),
+  media: MediaAssetSchema.optional(),
   questions: z.array(QuestionSchema).min(1).max(10),
 });
 
@@ -33,7 +38,7 @@ const GameConfigSchema = z.object({
   finalChallengeEnabled: z.boolean(),
   finalChallengeClue: z.string().max(2000),
   finalChallengeAnswer: z.string().max(500),
-  finalChallengeMedia: z.object({ type: z.enum(['image', 'audio']), filename: z.string() }).optional(),
+  finalChallengeMedia: MediaAssetSchema.optional(),
 });
 
 // GET /api/games — listar jogos

--- a/packages/server/src/routes/mediaRoutes.ts
+++ b/packages/server/src/routes/mediaRoutes.ts
@@ -1,13 +1,18 @@
 import { Router, Request, type IRouter } from 'express';
 import { randomUUID } from 'crypto';
-import { extname } from 'path';
+import { extname, resolve } from 'path';
+import { unlink } from 'fs/promises';
 import multer from 'multer';
 import { loadGame, getMediaDir } from '../storage/fileStorage.js';
+import { MEDIA_MAX_MB } from '../config.js';
 
 export const mediaRouter: IRouter = Router({ mergeParams: true });
 
-const ALLOWED_MIME = new Set(['image/jpeg', 'image/png', 'image/gif', 'image/webp']);
-const MAX_SIZE = 5 * 1024 * 1024; // 5 MB
+const ALLOWED_MIME = new Set([
+  'image/jpeg', 'image/png', 'image/gif', 'image/webp',
+  'audio/mpeg', 'audio/ogg', 'audio/wav', 'audio/x-wav', 'audio/wave', 'audio/mp4', 'audio/aac', 'audio/flac', 'audio/webm',
+]);
+const MAX_SIZE = MEDIA_MAX_MB * 1024 * 1024;
 
 type GameMediaRequest = Request<{ gameId: string }>;
 
@@ -27,10 +32,34 @@ const upload = multer({
     if (ALLOWED_MIME.has(file.mimetype)) {
       cb(null, true);
     } else {
-      cb(new Error('Tipo de arquivo não permitido. Use JPEG, PNG, GIF ou WebP.'));
+      cb(new Error('Tipo de arquivo não permitido. Use JPEG, PNG, GIF, WebP ou áudio (MP3, OGG, WAV, AAC).'));
     }
   },
   limits: { fileSize: MAX_SIZE },
+});
+
+// DELETE /api/games/:gameId/media/:filename
+mediaRouter.delete('/:filename', async (req: Request<{ gameId: string; filename: string }>, res) => {
+  const { gameId, filename } = req.params;
+
+  if (!/^[a-f0-9-]+\.[a-z]+$/i.test(filename)) {
+    res.status(400).json({ error: 'Nome de arquivo inválido' });
+    return;
+  }
+
+  const game = await loadGame(gameId);
+  if (!game) {
+    res.status(404).json({ error: 'Jogo não encontrado' });
+    return;
+  }
+
+  try {
+    const dir = await getMediaDir(gameId);
+    await unlink(resolve(dir, filename));
+    res.status(204).send();
+  } catch {
+    res.status(404).json({ error: 'Arquivo não encontrado' });
+  }
 });
 
 // POST /api/games/:gameId/media
@@ -50,8 +79,10 @@ mediaRouter.post('/', async (req: GameMediaRequest, res) => {
       res.status(400).json({ error: 'Arquivo não enviado' });
       return;
     }
+    const mediaType = req.file.mimetype.startsWith('audio/') ? 'audio' : 'image';
     res.status(201).json({
       filename: req.file.filename,
+      type: mediaType,
       url: `/media/${req.params.gameId}/${req.file.filename}`,
     });
   });

--- a/packages/server/src/server.ts
+++ b/packages/server/src/server.ts
@@ -5,7 +5,7 @@ import helmet from 'helmet';
 import cors from 'cors';
 import { resolve } from 'path';
 import type { ServerToClientEvents, ClientToServerEvents } from '@jeopardy/shared';
-import { PORT, CLIENT_URL, GAMES_DIR } from './config.js';
+import { PORT, CLIENT_URL, GAMES_DIR, NODE_ENV } from './config.js';
 import { apiLimiter } from './middleware/rateLimiter.js';
 import { gameRouter } from './routes/gameRoutes.js';
 import { mediaRouter } from './routes/mediaRoutes.js';
@@ -47,7 +47,7 @@ export function createApp(): { app: ReturnType<typeof express>; httpServer: Retu
   });
 
   // Em produção, servir o client buildado
-  if (process.env.NODE_ENV === 'production') {
+  if (NODE_ENV === 'production') {
     const clientDist = resolve(process.cwd(), '../client/dist');
     app.use(express.static(clientDist));
     app.get('*', (_req, res) => {

--- a/packages/shared/src/types/events.ts
+++ b/packages/shared/src/types/events.ts
@@ -1,6 +1,6 @@
 import type { GameConfig, MediaAsset } from './game.js';
 import type { Player } from './player.js';
-import type { ActiveQuestion, BuzzerEntry, GamePhase } from './state.js';
+import type { ActiveQuestion, BuzzerEntry, GamePhase, ChallengeState } from './state.js';
 
 // ============================================================
 // CLIENT → SERVER
@@ -59,6 +59,23 @@ export interface C2S_HostClearQuestion {
   hostToken: string;
 }
 
+export interface C2S_HostContinueBoard {
+  sessionId: string;
+  hostToken: string;
+}
+
+export interface C2S_HostAudioControl {
+  sessionId: string;
+  hostToken: string;
+  action: 'play' | 'pause' | 'seek';
+  currentTime: number;
+}
+
+export interface S2C_AudioSync {
+  action: 'play' | 'pause' | 'seek';
+  currentTime: number;
+}
+
 export interface C2S_HostStartFinal {
   sessionId: string;
   hostToken: string;
@@ -86,6 +103,27 @@ export interface C2S_PlayerFinalWager {
   playerId: string;
   amount: number;
   answer: string;
+}
+
+// Dupla Aposta: host atribui a um jogador
+export interface C2S_HostAssignDouble {
+  sessionId: string;
+  hostToken: string;
+  playerId: string;
+}
+
+// Dupla Aposta: jogador envia a aposta
+export interface C2S_PlayerDoubleWager {
+  sessionId: string;
+  playerId: string;
+  amount: number;
+}
+
+// Challenge: host seleciona quem será desafiado
+export interface C2S_HostSetChallenge {
+  sessionId: string;
+  hostToken: string;
+  challengedId: string;
 }
 
 // ============================================================
@@ -127,6 +165,10 @@ export interface S2C_QuestionClosed {
   questionId: string;
   categoryId: string;
   phase: GamePhase;
+}
+
+export interface S2C_QuestionAnswerReveal {
+  phase: 'answer_reveal';
 }
 
 export interface S2C_BuzzerConfirmed {
@@ -199,6 +241,23 @@ export interface S2C_GameOver {
   winnerId: string;
 }
 
+// Dupla Aposta: anuncio do jogador atribuído (null = aguardando atribuição)
+export interface S2C_DoubleStarted {
+  assignedPlayerId: string | null;
+  assignedPlayerName: string | null;
+}
+
+// Dupla Aposta: aposta confirmada, clue vai revelar
+export interface S2C_DoubleWagerLocked {
+  assignedPlayerId: string;
+  amount: number;
+}
+
+// Challenge: host definiu o par desafiador/desafiado
+export interface S2C_ChallengeAssigned {
+  challengeState: ChallengeState;
+}
+
 // ============================================================
 // Mapa de eventos tipados para uso no Socket.io
 // ============================================================
@@ -211,6 +270,8 @@ export interface ServerToClientEvents {
   'game:started': (data: S2C_GameStarted) => void;
   'question:selected': (data: S2C_QuestionSelected) => void;
   'question:closed': (data: S2C_QuestionClosed) => void;
+  'question:answerReveal': (data: S2C_QuestionAnswerReveal) => void;
+  'audio:sync': (data: S2C_AudioSync) => void;
   'buzzer:opened': () => void;
   'buzzer:confirmed': (data: S2C_BuzzerConfirmed) => void;
   'buzzer:queueUpdate': (data: S2C_BuzzerQueueUpdate) => void;
@@ -223,6 +284,9 @@ export interface ServerToClientEvents {
   'final:hostDetails': (data: S2C_FinalHostDetails) => void;
   'final:revealed': (data: S2C_FinalRevealed) => void;
   'game:over': (data: S2C_GameOver) => void;
+  'double:started': (data: S2C_DoubleStarted) => void;
+  'double:wagerLocked': (data: S2C_DoubleWagerLocked) => void;
+  'challenge:assigned': (data: S2C_ChallengeAssigned) => void;
 }
 
 export interface ClientToServerEvents {
@@ -235,9 +299,14 @@ export interface ClientToServerEvents {
   'host:adjustScore': (data: C2S_HostAdjustScore) => void;
   'host:timerControl': (data: C2S_HostTimerControl) => void;
   'host:clearQuestion': (data: C2S_HostClearQuestion) => void;
+  'host:continueBoard': (data: C2S_HostContinueBoard) => void;
+  'host:audioControl': (data: C2S_HostAudioControl) => void;
   'host:startFinal': (data: C2S_HostStartFinal) => void;
   'host:revealFinal': (data: C2S_HostRevealFinal) => void;
   'host:endGame': (data: C2S_HostEndGame) => void;
   'player:buzz': (data: C2S_PlayerBuzz) => void;
   'player:finalWager': (data: C2S_PlayerFinalWager) => void;
+  'host:assignDouble': (data: C2S_HostAssignDouble) => void;
+  'player:doubleWager': (data: C2S_PlayerDoubleWager) => void;
+  'host:setChallenge': (data: C2S_HostSetChallenge) => void;
 }

--- a/packages/shared/src/types/game.ts
+++ b/packages/shared/src/types/game.ts
@@ -12,7 +12,10 @@ export interface Question {
   clue: string;
   answer: string;
   type: QuestionType;
-  media?: MediaAsset;
+  media?: MediaAsset;      // imagem do clue
+  clueAudio?: MediaAsset;  // áudio do clue
+  answerMedia?: MediaAsset; // imagem da resposta
+  answerAudio?: MediaAsset; // áudio da resposta
   used: boolean;
   challengeTarget?: string;
   timeOverride?: number;

--- a/packages/shared/src/types/state.ts
+++ b/packages/shared/src/types/state.ts
@@ -8,9 +8,18 @@ export type GamePhase =
   | 'question'
   | 'buzzer_queue'
   | 'all_play'
+  | 'double_wager'
+  | 'answer_reveal'
   | 'final_challenge'
   | 'final_reveal'
   | 'game_over';
+
+export interface ChallengeState {
+  challengerId: string;
+  challengerName: string;
+  challengedId: string | null;
+  challengedName: string | null;
+}
 
 export interface BuzzerEntry {
   playerId: string;
@@ -39,6 +48,11 @@ export interface GameSession {
   activeQuestion: ActiveQuestion | null;
   buzzerQueue: BuzzerEntry[];
   finalChallengeWagers: Record<string, FinalChallengeWager>;
+  // Double (Dupla Aposta)
+  doublePlayerId: string | null;
+  doubleWager: number | null;
+  // Challenge
+  challengeState: ChallengeState | null;
   startedAt?: number;
   endedAt?: number;
 }


### PR DESCRIPTION
## Resumo

- **REST CRUD completo** — `GET/POST/PUT/DELETE /api/games` com validação Zod e persistência em disco (`data/games/:id/config.json`)
- **Upload de mídia** — `POST /api/games/:id/media` com Multer; suporte a JPEG, PNG, GIF, WebP, MP3, OGG, WAV (+ variantes), AAC, FLAC; limite configurável via `.env`
- **4 slots de mídia por questão** — imagem do clue, áudio do clue, imagem da resposta, áudio da resposta
- **Imagem de header por categoria** no board
- **Game Editor** completo — CRUD, upload inline, add/remove questões individuais (1–10 por categoria), campo de dica para questão challenge
- **Fase `answer_reveal`** — host revela clue + resposta + mídia antes de voltar ao board
- **Sync de áudio host → players** — play/pause/seek sincronizados via socket; correção de bug crítico com AnimatePresence + callback ref
- **Questão `all_play`** — buzzer abre para todos imediatamente ao selecionar
- **Questão `challenge`** — desafiador (primeiro a buzzar) escolhe quem desafiar; scoring especial: desafiado ±valor, desafiador ∓valor/2
- **Questão `double` (Dupla Aposta)** — host atribui a um jogador; jogador aposta antes de ver o clue; score = ±aposta
- **`finalChallengeMedia`** exibida na tela do player durante o Desafio Final
- **`.env` + `.env.example`** — todas as variáveis configuráveis extraídas (porta, limites, TTL, etc.)
- **localtunnel, HMAC hostToken e rate limiting** antecipados da Fase 3

## Teste

- [x] Criar jogo no editor com pelo menos 2 categorias e questões de todos os tipos
- [x] Fazer upload de imagem e áudio por questão e por categoria
- [x] Hospedar sessão, entrar com 2+ players e jogar uma questão `standard` até `answer_reveal`
- [x] Verificar sync de áudio: host play/pause/seek reflete nos players
- [x] Jogar questão `all_play` — todos podem buzzar simultaneamente
- [x] Jogar questão `challenge` — host atribui desafiado, scores corretos
- [x] Jogar questão `double` — wager antes do clue, score ±aposta
- [x] Verificar `finalChallengeMedia` na tela do player

🤖 Generated with [Claude Code](https://claude.com/claude-code)