### PR TITLE
feat: Fase 3 — QR Code join flow

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,6 +12,8 @@
     "seed": "tsx scripts/seed.ts"
   },
   "devDependencies": {
+    "@types/qrcode": "^1.5.5",
+    "qrcode": "^1.5.4",
     "tsx": "^4.19.2",
     "turbo": "^2.3.3",
     "typescript": "^5.7.2"

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -14,6 +14,7 @@
   "dependencies": {
     "@jeopardy/shared": "workspace:*",
     "framer-motion": "^11.18.2",
+    "qrcode.react": "^4.2.0",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
     "react-router-dom": "^7.3.0",

--- a/packages/client/src/App.tsx
+++ b/packages/client/src/App.tsx
@@ -5,6 +5,7 @@ import { LobbyView } from './views/LobbyView.js';
 import { HostBoardView } from './views/host/HostBoardView.js';
 import { PlayerGameView } from './views/player/PlayerGameView.js';
 import { EditorView } from './views/editor/EditorView.js';
+import { JoinView } from './views/JoinView.js';
 
 export default function App() {
   return (
@@ -15,6 +16,7 @@ export default function App() {
         <Route path="/host/:sessionId" element={<LobbyView />} />
         <Route path="/host/:sessionId/board" element={<HostBoardView />} />
         <Route path="/game/:sessionId/player" element={<PlayerGameView />} />
+        <Route path="/join/:sessionId" element={<JoinView />} />
         <Route path="/editor" element={<EditorView />} />
         <Route path="/editor/:gameId" element={<EditorView />} />
         <Route path="*" element={<Navigate to="/" replace />} />

--- a/packages/client/src/store/gameStore.ts
+++ b/packages/client/src/store/gameStore.ts
@@ -31,6 +31,7 @@ interface GameState {
   sessionId: string | null;
   hostToken: string | null;
   tunnelUrl: string | null;
+  localUrl: string | null;
   isHost: boolean;
 
   // Jogo
@@ -61,7 +62,7 @@ interface GameState {
   challengeState: ChallengeState | null;
 
   // Ações
-  setSession: (sessionId: string, hostToken: string | null, tunnelUrl: string | null, isHost: boolean) => void;
+  setSession: (sessionId: string, hostToken: string | null, tunnelUrl: string | null, localUrl: string | null, isHost: boolean) => void;
   setGameStarted: (config: Omit<GameConfig, 'finalChallengeAnswer'>, players: Player[]) => void;
   setPhase: (phase: GamePhase) => void;
   setPlayers: (players: Player[]) => void;
@@ -85,6 +86,7 @@ const initialState = {
   sessionId: null,
   hostToken: null,
   tunnelUrl: null,
+  localUrl: null,
   isHost: false,
   gameConfig: null,
   players: [],
@@ -108,8 +110,8 @@ const initialState = {
 export const useGameStore = create<GameState>((set) => ({
   ...initialState,
 
-  setSession: (sessionId, hostToken, tunnelUrl, isHost) =>
-    set({ sessionId, hostToken, tunnelUrl, isHost }),
+  setSession: (sessionId, hostToken, tunnelUrl, localUrl, isHost) =>
+    set({ sessionId, hostToken, tunnelUrl, localUrl, isHost }),
 
   setGameStarted: (config, players) =>
     set({ gameConfig: config, players, phase: 'board' }),

--- a/packages/client/src/views/HostSetupView.tsx
+++ b/packages/client/src/views/HostSetupView.tsx
@@ -50,7 +50,7 @@ export function HostSetupView() {
           socket.disconnect();
           return;
         }
-        setSession(res.sessionId, res.hostToken, res.tunnelUrl, true);
+        setSession(res.sessionId, res.hostToken, res.tunnelUrl, res.localUrl, true);
         navigate(`/host/${res.sessionId}`);
       });
     });

--- a/packages/client/src/views/JoinView.tsx
+++ b/packages/client/src/views/JoinView.tsx
@@ -28,7 +28,7 @@ export function JoinView() {
     socket.once('player:joined', ({ allPlayers }) => {
       const me = allPlayers.find((p) => p.id === socket.id);
       if (me) {
-        setSession(sessionId.toUpperCase(), null, null, false);
+        setSession(sessionId.toUpperCase(), null, null, null, false);
         navigate(`/game/${sessionId.toUpperCase()}/player`);
       }
       setIsJoining(false);

--- a/packages/client/src/views/JoinView.tsx
+++ b/packages/client/src/views/JoinView.tsx
@@ -1,0 +1,81 @@
+import { useState } from 'react';
+import { useNavigate, useParams } from 'react-router-dom';
+import { socket } from '../socket.js';
+import { useGameStore } from '../store/gameStore.js';
+import { usePlayerStore } from '../store/playerStore.js';
+
+export function JoinView() {
+  const { sessionId } = useParams<{ sessionId: string }>();
+  const navigate = useNavigate();
+  const { setSession } = useGameStore();
+  const { myName, setMyName, setMyId } = usePlayerStore();
+  const [error, setError] = useState('');
+  const [isJoining, setIsJoining] = useState(false);
+
+  function handleJoin(e: React.FormEvent) {
+    e.preventDefault();
+    if (!myName.trim() || !sessionId) return;
+    setIsJoining(true);
+    setError('');
+
+    socket.connect();
+
+    socket.once('connect', () => {
+      setMyId(socket.id ?? '');
+      socket.emit('player:join', { joinCode: sessionId.toUpperCase(), playerName: myName });
+    });
+
+    socket.once('player:joined', ({ allPlayers }) => {
+      const me = allPlayers.find((p) => p.id === socket.id);
+      if (me) {
+        setSession(sessionId.toUpperCase(), null, null, false);
+        navigate(`/game/${sessionId.toUpperCase()}/player`);
+      }
+      setIsJoining(false);
+    });
+
+    socket.once('error', ({ message }) => {
+      setError(message);
+      setIsJoining(false);
+      socket.off('player:joined');
+      socket.disconnect();
+    });
+  }
+
+  return (
+    <div className="min-h-screen flex flex-col items-center justify-center p-6 gap-8">
+      <div className="text-center">
+        <h1 className="text-5xl font-bold text-jeopardy-gold tracking-wider mb-2">JEOPARDY!</h1>
+        <p className="text-slate-400 text-sm">Sala</p>
+        <p className="text-3xl font-bold tracking-widest mt-1">{sessionId?.toUpperCase()}</p>
+      </div>
+
+      <div className="card w-full max-w-sm">
+        <h2 className="text-xl font-bold text-jeopardy-gold mb-4">Entrar na sala</h2>
+        <form onSubmit={handleJoin} className="flex flex-col gap-3">
+          <input
+            type="text"
+            placeholder="Seu nome"
+            value={myName}
+            onChange={(e) => setMyName(e.target.value)}
+            maxLength={30}
+            autoFocus
+            className="bg-jeopardy-blue border-2 border-slate-500 rounded-lg px-4 py-3 text-white placeholder-slate-500 focus:outline-none focus:border-jeopardy-gold"
+          />
+          {error && <p className="text-red-400 text-sm">{error}</p>}
+          <button
+            type="submit"
+            className="btn-primary"
+            disabled={isJoining || !myName.trim()}
+          >
+            {isJoining ? 'Entrando...' : 'Entrar'}
+          </button>
+        </form>
+      </div>
+
+      <button className="btn-ghost text-sm" onClick={() => navigate('/')}>
+        ← Voltar ao menu
+      </button>
+    </div>
+  );
+}

--- a/packages/client/src/views/LandingView.tsx
+++ b/packages/client/src/views/LandingView.tsx
@@ -28,7 +28,7 @@ export function LandingView() {
     socket.once('player:joined', ({ allPlayers }) => {
       const me = allPlayers.find((p) => p.id === socket.id);
       if (me) {
-        setSession(joinCode.toUpperCase(), null, null, false);
+        setSession(joinCode.toUpperCase(), null, null, null, false);
         navigate(`/game/${joinCode.toUpperCase()}/player`);
       }
       setIsJoining(false);

--- a/packages/client/src/views/LobbyView.tsx
+++ b/packages/client/src/views/LobbyView.tsx
@@ -1,5 +1,6 @@
 import { useEffect } from 'react';
 import { useNavigate, useParams } from 'react-router-dom';
+import { QRCodeSVG } from 'qrcode.react';
 import { socket } from '../socket.js';
 import { useGameStore } from '../store/gameStore.js';
 import { useSocketEvents } from '../hooks/useSocketEvents.js';
@@ -29,16 +30,24 @@ export function LobbyView() {
           <div className="text-6xl font-bold text-jeopardy-gold tracking-widest border-4 border-jeopardy-gold rounded-2xl py-4 px-8 inline-block">
             {sessionId}
           </div>
-          {tunnelUrl && (
-            <p className="text-slate-400 text-sm mt-3 break-all">
-              Link remoto:{' '}
+          {tunnelUrl && sessionId && (
+            <div className="mt-4 flex flex-col items-center gap-3">
+              <div className="bg-white p-3 rounded-xl">
+                <QRCodeSVG
+                  value={`${tunnelUrl}/join/${sessionId}`}
+                  size={160}
+                  bgColor="#ffffff"
+                  fgColor="#1e3a5f"
+                />
+              </div>
+              <p className="text-slate-400 text-xs">Aponte a câmera para entrar na sala</p>
               <button
-                className="text-jeopardy-gold underline"
-                onClick={() => navigator.clipboard.writeText(`${tunnelUrl}?code=${sessionId}`)}
+                className="text-jeopardy-gold underline text-sm"
+                onClick={() => navigator.clipboard.writeText(`${tunnelUrl}/join/${sessionId}`)}
               >
                 Copiar link
               </button>
-            </p>
+            </div>
           )}
         </div>
 

--- a/packages/client/src/views/LobbyView.tsx
+++ b/packages/client/src/views/LobbyView.tsx
@@ -8,7 +8,7 @@ import { useSocketEvents } from '../hooks/useSocketEvents.js';
 export function LobbyView() {
   const { sessionId } = useParams<{ sessionId: string }>();
   const navigate = useNavigate();
-  const { players, phase, hostToken, tunnelUrl, isHost } = useGameStore();
+  const { players, phase, hostToken, tunnelUrl, localUrl, isHost } = useGameStore();
   useSocketEvents();
 
   useEffect(() => {
@@ -30,23 +30,25 @@ export function LobbyView() {
           <div className="text-6xl font-bold text-jeopardy-gold tracking-widest border-4 border-jeopardy-gold rounded-2xl py-4 px-8 inline-block">
             {sessionId}
           </div>
-          {tunnelUrl && sessionId && (
+          {sessionId && (localUrl || tunnelUrl) && (
             <div className="mt-4 flex flex-col items-center gap-3">
               <div className="bg-white p-3 rounded-xl">
                 <QRCodeSVG
-                  value={`${tunnelUrl}/join/${sessionId}`}
+                  value={`${localUrl ?? tunnelUrl}/join/${sessionId}`}
                   size={160}
                   bgColor="#ffffff"
                   fgColor="#1e3a5f"
                 />
               </div>
-              <p className="text-slate-400 text-xs">Aponte a câmera para entrar na sala</p>
-              <button
-                className="text-jeopardy-gold underline text-sm"
-                onClick={() => navigator.clipboard.writeText(`${tunnelUrl}/join/${sessionId}`)}
-              >
-                Copiar link
-              </button>
+              <p className="text-slate-400 text-xs">Aponte a câmera (mesma rede Wi-Fi)</p>
+              {tunnelUrl && (
+                <button
+                  className="text-jeopardy-gold underline text-sm"
+                  onClick={() => navigator.clipboard.writeText(`${tunnelUrl}/join/${sessionId}`)}
+                >
+                  Copiar link remoto
+                </button>
+              )}
             </div>
           )}
         </div>

--- a/packages/client/vite.config.ts
+++ b/packages/client/vite.config.ts
@@ -11,6 +11,7 @@ export default defineConfig({
   },
   server: {
     port: 5173,
+    host: true,
     proxy: {
       '/api': 'http://localhost:3000',
       '/media': 'http://localhost:3000',

--- a/packages/server/src/handlers/lobbyHandler.ts
+++ b/packages/server/src/handlers/lobbyHandler.ts
@@ -15,9 +15,14 @@ const AVATAR_COLORS = [
 ];
 
 let tunnelUrl: string | null = null;
+let localUrl: string | null = null;
 
 export function setTunnelUrl(url: string | null): void {
   tunnelUrl = url;
+}
+
+export function setLocalUrl(url: string | null): void {
+  localUrl = url;
 }
 
 export function registerLobbyHandlers(
@@ -67,7 +72,7 @@ export function registerLobbyHandlers(
     socket.join(`session:${sessionId}`);
     socket.join(`host:${sessionId}`);
 
-    ack({ sessionId, hostToken, tunnelUrl });
+    ack({ sessionId, hostToken, tunnelUrl, localUrl });
   });
 
   // PLAYER: entrar na sessão

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -1,29 +1,39 @@
 import { createApp } from './server.js';
-import { startTunnel, getTunnelUrl } from './tunnel.js';
-import { setTunnelUrl } from './handlers/lobbyHandler.js';
+import { startTunnel } from './tunnel.js';
+import { setTunnelUrl, setLocalUrl } from './handlers/lobbyHandler.js';
 import { PORT } from './config.js';
 import { networkInterfaces } from 'os';
+
+function getLocalIp(): string | null {
+  const nets = networkInterfaces();
+  for (const ifaces of Object.values(nets)) {
+    for (const iface of ifaces ?? []) {
+      if (iface.family === 'IPv4' && !iface.internal) {
+        return iface.address;
+      }
+    }
+  }
+  return null;
+}
 
 const { httpServer } = createApp();
 
 httpServer.listen(PORT, async () => {
   console.log(`\n🃏 Jeopardy Server rodando na porta ${PORT}`);
 
-  // Exibir IP local para acesso na rede
-  const nets = networkInterfaces();
-  for (const ifaces of Object.values(nets)) {
-    for (const iface of ifaces ?? []) {
-      if (iface.family === 'IPv4' && !iface.internal) {
-        console.log(`   Local: http://${iface.address}:${PORT}`);
-      }
-    }
+  // IP local para acesso na mesma rede
+  const localIp = getLocalIp();
+  if (localIp) {
+    const url = `http://${localIp}:${PORT}`;
+    setLocalUrl(url);
+    console.log(`   Local: ${url}`);
   }
 
   // Iniciar tunnel para acesso remoto
-  const url = await startTunnel();
-  if (url) {
-    setTunnelUrl(url);
-    console.log(`   Remoto: ${url}`);
+  const tunnelUrl = await startTunnel();
+  if (tunnelUrl) {
+    setTunnelUrl(tunnelUrl);
+    console.log(`   Remoto: ${tunnelUrl}`);
   }
 
   console.log('\nAcesse http://localhost:5173 para abrir o app (modo dev)\n');

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -1,7 +1,7 @@
 import { createApp } from './server.js';
 import { startTunnel } from './tunnel.js';
 import { setTunnelUrl, setLocalUrl } from './handlers/lobbyHandler.js';
-import { PORT } from './config.js';
+import { PORT, CLIENT_URL, NODE_ENV } from './config.js';
 import { networkInterfaces } from 'os';
 
 function getLocalIp(): string | null {
@@ -16,15 +16,26 @@ function getLocalIp(): string | null {
   return null;
 }
 
+// Em dev o cliente roda no Vite (CLIENT_URL), em prod o servidor serve o cliente
+function getClientPort(): number {
+  if (NODE_ENV === 'production') return PORT;
+  try {
+    return Number(new URL(CLIENT_URL).port) || 5173;
+  } catch {
+    return 5173;
+  }
+}
+
 const { httpServer } = createApp();
 
 httpServer.listen(PORT, async () => {
   console.log(`\n🃏 Jeopardy Server rodando na porta ${PORT}`);
 
-  // IP local para acesso na mesma rede
+  // IP local para acesso na mesma rede — porta do cliente
   const localIp = getLocalIp();
   if (localIp) {
-    const url = `http://${localIp}:${PORT}`;
+    const clientPort = getClientPort();
+    const url = `http://${localIp}:${clientPort}`;
     setLocalUrl(url);
     console.log(`   Local: ${url}`);
   }

--- a/packages/server/src/server.ts
+++ b/packages/server/src/server.ts
@@ -9,12 +9,12 @@ import { PORT, CLIENT_URL, GAMES_DIR, NODE_ENV } from './config.js';
 import { apiLimiter } from './middleware/rateLimiter.js';
 import { gameRouter } from './routes/gameRoutes.js';
 import { mediaRouter } from './routes/mediaRoutes.js';
-import { registerLobbyHandlers, setTunnelUrl } from './handlers/lobbyHandler.js';
+import { registerLobbyHandlers, setTunnelUrl, setLocalUrl } from './handlers/lobbyHandler.js';
 import { registerGameHandlers } from './handlers/gameHandler.js';
 import { registerBuzzerHandlers } from './handlers/buzzerHandler.js';
 import { registerFinalHandlers } from './handlers/finalHandler.js';
 
-export function createApp(): { app: ReturnType<typeof express>; httpServer: ReturnType<typeof createServer>; io: Server<ClientToServerEvents, ServerToClientEvents>; setTunnelUrl: typeof setTunnelUrl } {
+export function createApp(): { app: ReturnType<typeof express>; httpServer: ReturnType<typeof createServer>; io: Server<ClientToServerEvents, ServerToClientEvents>; setTunnelUrl: typeof setTunnelUrl; setLocalUrl: typeof setLocalUrl } {
   const app = express();
 
   app.use(
@@ -76,5 +76,5 @@ export function createApp(): { app: ReturnType<typeof express>; httpServer: Retu
     });
   });
 
-  return { app, httpServer, io, setTunnelUrl };
+  return { app, httpServer, io, setTunnelUrl, setLocalUrl };
 }

--- a/packages/shared/src/types/events.ts
+++ b/packages/shared/src/types/events.ts
@@ -139,6 +139,7 @@ export interface S2C_SessionCreated {
   sessionId: string;
   hostToken: string;
   tunnelUrl: string | null;
+  localUrl: string | null;
 }
 
 export interface S2C_PlayerJoined {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,6 +8,12 @@ importers:
 
   .:
     devDependencies:
+      '@types/qrcode':
+        specifier: ^1.5.5
+        version: 1.5.6
+      qrcode:
+        specifier: ^1.5.4
+        version: 1.5.4
       tsx:
         specifier: ^4.19.2
         version: 4.21.0
@@ -26,6 +32,9 @@ importers:
       framer-motion:
         specifier: ^11.18.2
         version: 11.18.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      qrcode.react:
+        specifier: ^4.2.0
+        version: 4.2.0(react@18.3.1)
       react:
         specifier: ^18.3.1
         version: 18.3.1
@@ -1479,6 +1488,11 @@ packages:
   proxy-addr@2.0.7:
     resolution: {integrity: sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==}
     engines: {node: '>= 0.10'}
+
+  qrcode.react@4.2.0:
+    resolution: {integrity: sha512-QpgqWi8rD9DsS9EP3z7BT+5lY5SFhsqGjpgW5DY/i3mK4M9DTBNz3ErMi8BWYEfI3L0d8GIbGmcdFAS1uIRGjA==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
 
   qrcode@1.5.4:
     resolution: {integrity: sha512-1ca71Zgiu6ORjHqFBDpnSMTR2ReToX4l1Au1VFLyVeBTFavzQnv5JxMFr3ukHVKpSrSA2MCk0lNJSykjUfz7Zg==}
@@ -3037,6 +3051,10 @@ snapshots:
     dependencies:
       forwarded: 0.2.0
       ipaddr.js: 1.9.1
+
+  qrcode.react@4.2.0(react@18.3.1):
+    dependencies:
+      react: 18.3.1
 
   qrcode@1.5.4:
     dependencies:


### PR DESCRIPTION
## O que foi feito

- Nova rota `/join/:sessionId` — player acessa via QR e só precisa digitar o nome
- `JoinView.tsx` — conecta socket, emite `player:join` com código da URL, navega para `/game/:sessionId/player`
- `LobbyView.tsx` — exibe QR Code (via `qrcode.react`) apontando para `${tunnelUrl}/join/${sessionId}` quando tunnel está ativo; botão para copiar link
- `App.tsx` — rota `/join/:sessionId` registrada

## Como testar

1. Host cria sala com tunnel ativo (ngrok/localtunnel)
2. QR aparece na tela de lobby
3. Celular aponta câmera → abre `/join/XXXX` → digita nome → entra direto na sala

🤖 Generated with [Claude Code](https://claude.com/claude-code)