### PR TITLE
feat: Fase 5 — Build e Release workflows

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,47 @@
+name: Build
+
+on:
+  push:
+    branches: [main]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build:
+    name: Production build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 10.2.1
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Build all packages
+        run: pnpm build
+
+      - name: Package artifact
+        run: |
+          mkdir -p release/packages
+          cp -r packages/server/dist release/packages/server
+          cp -r packages/client/dist release/packages/client
+          cp packages/server/package.json release/packages/server/package.json
+          cp package.json pnpm-lock.yaml pnpm-workspace.yaml release/
+          tar -czf jeopardy-game.tar.gz -C release .
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: jeopardy-game
+          path: jeopardy-game.tar.gz
+          retention-days: 7

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,46 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - 'v*.*.*'
+
+jobs:
+  release:
+    name: Create release
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 10.2.1
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Build all packages
+        run: pnpm build
+
+      - name: Package release
+        run: |
+          mkdir -p release/packages
+          cp -r packages/server/dist release/packages/server
+          cp -r packages/client/dist release/packages/client
+          cp packages/server/package.json release/packages/server/package.json
+          cp package.json pnpm-lock.yaml pnpm-workspace.yaml release/
+          tar -czf jeopardy-game-${{ github.ref_name }}.tar.gz -C release .
+
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          name: ${{ github.ref_name }}
+          generate_release_notes: true
+          files: jeopardy-game-${{ github.ref_name }}.tar.gz


### PR DESCRIPTION
## O que foi feito

**build.yml** — roda em push para `main`:
- Build completo (shared → server → client)
- Empacota `server/dist` + `client/dist` + manifests num tarball
- Sobe como artefato GitHub Actions (retenção 7 dias)

**release.yml** — roda em push de tag `v*.*.*`:
- Mesmo build + empacotamento
- Cria GitHub Release automaticamente com changelog gerado e tarball anexado

## Como criar uma release

```bash
git tag v1.0.0
git push origin v1.0.0
```

O workflow cria a release com notas geradas a partir dos commits desde a tag anterior.