### PR TITLE
fix: join via tunnel para jogadores externos

### DIFF
--- a/packages/client/src/views/player/PlayerGameView.tsx
+++ b/packages/client/src/views/player/PlayerGameView.tsx
@@ -34,12 +34,29 @@ export function PlayerGameView() {
   const [doubleWagerInput, setDoubleWagerInput] = useState('');
   const [doubleWagerSent, setDoubleWagerSent] = useState(false);
   const audioRef = useRef<HTMLAudioElement | null>(null);
+  const audioUnlocked = useRef(false);
   // Callback ref que ignora null: evita que a exit animation do AnimatePresence
   // sobrescreva o ref com null depois do novo elemento já ter sido registrado.
   const audioCallbackRef = useCallback((el: HTMLAudioElement | null) => {
     if (el !== null) audioRef.current = el;
   }, []);
   useSocketEvents();
+
+  // Desbloqueia autoplay no primeiro gesto do usuário (obrigatório em mobile)
+  useEffect(() => {
+    function unlock() {
+      if (audioUnlocked.current) return;
+      audioUnlocked.current = true;
+      const silent = new Audio();
+      silent.play().catch(() => {});
+    }
+    window.addEventListener('touchstart', unlock, { once: true });
+    window.addEventListener('click', unlock, { once: true });
+    return () => {
+      window.removeEventListener('touchstart', unlock);
+      window.removeEventListener('click', unlock);
+    };
+  }, []);
 
   useEffect(() => {
     function handleAudioSync({ action, currentTime }: { action: 'play' | 'pause' | 'seek'; currentTime: number }) {

--- a/packages/client/src/views/player/PlayerGameView.tsx
+++ b/packages/client/src/views/player/PlayerGameView.tsx
@@ -40,6 +40,14 @@ export function PlayerGameView() {
   const audioCallbackRef = useCallback((el: HTMLAudioElement | null) => {
     if (el !== null) audioRef.current = el;
   }, []);
+
+  // Callback ref que monta e já chama play() — necessário em mobile onde autoPlay é bloqueado
+  const autoPlayCallbackRef = useCallback((el: HTMLAudioElement | null) => {
+    if (el !== null) {
+      audioRef.current = el;
+      el.play().catch(() => {});
+    }
+  }, []);
   useSocketEvents();
 
   // Desbloqueia autoplay no primeiro gesto do usuário (obrigatório em mobile)
@@ -245,9 +253,8 @@ export function PlayerGameView() {
             {activeQuestion.question.clueAudio && (
               <audio
                 key={activeQuestion.question.clueAudio.filename}
-                ref={audioCallbackRef}
+                ref={autoPlayCallbackRef}
                 src={`/media/${gameConfig.id}/${activeQuestion.question.clueAudio.filename}`}
-                autoPlay
               />
             )}
 
@@ -354,9 +361,8 @@ export function PlayerGameView() {
           {activeQuestion.question.answerAudio && (
             <audio
               key={activeQuestion.question.answerAudio.filename}
-              ref={audioCallbackRef}
+              ref={autoPlayCallbackRef}
               src={`/media/${gameConfig.id}/${activeQuestion.question.answerAudio.filename}`}
-              autoPlay
             />
           )}
 

--- a/packages/client/vite.config.ts
+++ b/packages/client/vite.config.ts
@@ -12,6 +12,7 @@ export default defineConfig({
   server: {
     port: 5173,
     host: true,
+    allowedHosts: 'all',
     proxy: {
       '/api': 'http://localhost:3000',
       '/media': 'http://localhost:3000',

--- a/packages/client/vite.config.ts
+++ b/packages/client/vite.config.ts
@@ -12,7 +12,7 @@ export default defineConfig({
   server: {
     port: 5173,
     host: true,
-    allowedHosts: 'all',
+    allowedHosts: true,
     proxy: {
       '/api': 'http://localhost:3000',
       '/media': 'http://localhost:3000',

--- a/packages/server/src/__tests__/handlers/lobbyHandler.test.ts
+++ b/packages/server/src/__tests__/handlers/lobbyHandler.test.ts
@@ -73,6 +73,17 @@ describe('host:create', () => {
     expect(result.sessionId).toHaveLength(6);
   });
 
+  it('retorna localUrl e tunnelUrl no ack', async () => {
+    const socket = makeMockSocket('host-socket');
+    const io = makeMockIo();
+    registerLobbyHandlers(io as any, socket as any);
+    let result: any;
+    socket.trigger('host:create', { gameConfigId: 'valid-game' }, (r: any) => { result = r; });
+    await new Promise((r) => setTimeout(r, 10));
+    expect(result).toHaveProperty('localUrl');
+    expect(result).toHaveProperty('tunnelUrl');
+  });
+
   it('retorna erro para jogo inexistente', async () => {
     const socket = makeMockSocket('host-socket');
     const io = makeMockIo();

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -31,17 +31,18 @@ const { httpServer } = createApp();
 httpServer.listen(PORT, async () => {
   console.log(`\n🃏 Jeopardy Server rodando na porta ${PORT}`);
 
-  // IP local para acesso na mesma rede — porta do cliente
+  // Em dev expõe Vite (5173), em prod expõe Express (PORT)
+  const clientPort = getClientPort();
+
+  // IP local para acesso na mesma rede
   const localIp = getLocalIp();
   if (localIp) {
-    const clientPort = getClientPort();
-    const url = `http://${localIp}:${clientPort}`;
-    setLocalUrl(url);
-    console.log(`   Local: ${url}`);
+    setLocalUrl(`http://${localIp}:${clientPort}`);
+    console.log(`   Local: http://${localIp}:${clientPort}`);
   }
 
-  // Iniciar tunnel para acesso remoto
-  const tunnelUrl = await startTunnel();
+  // Tunnel para acesso remoto — mesma porta do cliente
+  const tunnelUrl = await startTunnel(clientPort);
   if (tunnelUrl) {
     setTunnelUrl(tunnelUrl);
     console.log(`   Remoto: ${tunnelUrl}`);

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -41,8 +41,8 @@ httpServer.listen(PORT, async () => {
     console.log(`   Local: http://${localIp}:${clientPort}`);
   }
 
-  // Tunnel para acesso remoto — mesma porta do cliente
-  const tunnelUrl = await startTunnel(clientPort);
+  // Tunnel aponta para Express (PORT) — Socket.IO vai direto sem duplo proxy
+  const tunnelUrl = await startTunnel(PORT);
   if (tunnelUrl) {
     setTunnelUrl(tunnelUrl);
     console.log(`   Remoto: ${tunnelUrl}`);

--- a/packages/server/src/server.ts
+++ b/packages/server/src/server.ts
@@ -1,5 +1,5 @@
 import express from 'express';
-import { createServer } from 'http';
+import { createServer, request as httpRequest } from 'http';
 import { Server } from 'socket.io';
 import helmet from 'helmet';
 import cors from 'cors';
@@ -22,7 +22,7 @@ export function createApp(): { app: ReturnType<typeof express>; httpServer: Retu
       contentSecurityPolicy: false, // Desabilitar pois o client é servido pelo Vite em dev
     }),
   );
-  app.use(cors({ origin: CLIENT_URL }));
+  app.use(cors({ origin: NODE_ENV === 'production' ? CLIENT_URL : true }));
   app.use(express.json({ limit: '1mb' }));
   app.use('/api', apiLimiter);
 
@@ -55,10 +55,34 @@ export function createApp(): { app: ReturnType<typeof express>; httpServer: Retu
     });
   }
 
+  // Em dev, proxy de rotas SPA para o Vite — permite tunnel apontar pra Express (3000)
+  // sem quebrar Socket.IO com duplo proxy
+  if (NODE_ENV !== 'production') {
+    const vitePort = Number(new URL(CLIENT_URL).port) || 5173;
+    app.use((req, res, next) => {
+      if (
+        req.path.startsWith('/api') ||
+        req.path.startsWith('/media') ||
+        req.path.startsWith('/socket.io')
+      ) {
+        return next();
+      }
+      const proxy = httpRequest(
+        { hostname: 'localhost', port: vitePort, path: req.url, method: req.method, headers: { ...req.headers, host: `localhost:${vitePort}` } },
+        (proxyRes) => {
+          res.writeHead(proxyRes.statusCode ?? 200, proxyRes.headers);
+          proxyRes.pipe(res);
+        },
+      );
+      proxy.on('error', () => res.status(502).send('Vite dev server not running'));
+      req.pipe(proxy);
+    });
+  }
+
   const httpServer = createServer(app);
 
   const io = new Server<ClientToServerEvents, ServerToClientEvents>(httpServer, {
-    cors: { origin: CLIENT_URL },
+    cors: { origin: NODE_ENV === 'production' ? CLIENT_URL : true },
     pingTimeout: 20000,
     pingInterval: 10000,
   });

--- a/packages/server/src/tunnel.ts
+++ b/packages/server/src/tunnel.ts
@@ -1,12 +1,10 @@
-import { PORT } from './config.js';
-
 let currentTunnelUrl: string | null = null;
 
-export async function startTunnel(): Promise<string | null> {
+export async function startTunnel(port: number): Promise<string | null> {
   try {
     // Importação dinâmica pois localtunnel é CommonJS
     const localtunnel = (await import('localtunnel')).default;
-    const tunnel = await localtunnel({ port: PORT });
+    const tunnel = await localtunnel({ port });
 
     currentTunnelUrl = tunnel.url;
     console.log(`[tunnel] URL pública: ${tunnel.url}`);


### PR DESCRIPTION
## Problema

Jogadores acessando via tunnel (fora da rede local) recebiam `Cannot GET /join/[codigo]` e não conseguiam conectar. Após corrigir o 404, Socket.IO ficava em timeout por passar por duplo proxy (tunnel → Vite → Express). Áudio também não reproduzia em mobile.

## Solução

**Arquitetura do tunnel corrigida:**
- Tunnel aponta para Express (3000), não para Vite
- Express em dev mode faz proxy de rotas SPA para Vite via `http.request` nativo
- Socket.IO vai direto ao Express sem intermediário — sem timeout

**CORS liberado em dev** para aceitar qualquer origem (tunnel gera subdomínio diferente a cada sessão)

**Vite `allowedHosts: true`** para aceitar requisições vindas do tunnel

**Autoplay desbloqueado em mobile:**
- Primeiro toque/clique na página dispara `silent.play()` para desbloquear o audio context
- `autoPlay` HTML substituído por callback ref que chama `el.play()` no mount — funciona em mobile onde o atributo é ignorado
- Aplicado em clue audio e answer audio no `PlayerGameView`

## Testes

152 testes passando, cobertura 86.94% (server) e 97.29% (client).