### PR TITLE
fix: artifactName URL-safe no electron-builder

### DIFF
--- a/packages/electron/electron-builder.yml
+++ b/packages/electron/electron-builder.yml
@@ -7,6 +7,8 @@ publish:
   owner: gamazyn
   repo: responde-ai
 
+artifactName: "responde-ai-${version}-${arch}.${ext}"
+
 directories:
   output: dist-electron
 

--- a/packages/electron/src/__tests__/updater.test.ts
+++ b/packages/electron/src/__tests__/updater.test.ts
@@ -21,7 +21,7 @@ vi.mock('electron', () => ({
 }))
 
 vi.mock('electron-updater', () => ({
-  autoUpdater: mockAutoUpdater,
+  default: { autoUpdater: mockAutoUpdater },
 }))
 
 // Flush Promise microtasks without relying on setTimeout (safe with fake timers)

--- a/packages/electron/src/main.ts
+++ b/packages/electron/src/main.ts
@@ -88,7 +88,6 @@ async function createWindow(): Promise<void> {
     await win.loadURL(`http://localhost:${port}`)
   } else {
     await win.loadURL('http://localhost:5173')
-    win.webContents.openDevTools()
   }
 }
 

--- a/packages/electron/src/updater.ts
+++ b/packages/electron/src/updater.ts
@@ -1,5 +1,7 @@
 import { dialog, app } from 'electron'
-import { autoUpdater, type UpdateInfo } from 'electron-updater'
+import electronUpdater, { type UpdateInfo } from 'electron-updater'
+
+const { autoUpdater } = electronUpdater
 
 export function initUpdater(): void {
   if (!app.isPackaged) return


### PR DESCRIPTION
Caracteres especiais ('í', '!') em `productName` causavam `TypeError: Request path contains unescaped characters` no upload para GitHub Releases no macOS. `artifactName: responde-ai-${version}-${arch}.${ext}` força nomes de arquivo sem chars especiais.