### PR TITLE
Fase 7 — CI/Release health: Node 24 + README de releases

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,7 +15,7 @@ jobs:
     steps:
       - uses: actions/checkout@v5
 
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@v5
         with:
           version: 10.2.1
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,9 +4,6 @@ on:
   push:
     branches: [main]
 
-env:
-  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
-
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
@@ -16,13 +13,13 @@ jobs:
     name: Production build
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - uses: pnpm/action-setup@v4
         with:
           version: 10.2.1
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v5
         with:
           node-version: 22
           cache: pnpm

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,9 +6,6 @@ on:
   push:
     branches: [main]
 
-env:
-  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
-
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
@@ -18,13 +15,13 @@ jobs:
     name: type-check
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - uses: pnpm/action-setup@v4
         with:
           version: 10.2.1
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v5
         with:
           node-version: 22
           cache: pnpm
@@ -40,13 +37,13 @@ jobs:
     needs: [type-check]
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - uses: pnpm/action-setup@v4
         with:
           version: 10.2.1
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v5
         with:
           node-version: 22
           cache: pnpm
@@ -61,13 +58,13 @@ jobs:
     name: build
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - uses: pnpm/action-setup@v4
         with:
           version: 10.2.1
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v5
         with:
           node-version: 22
           cache: pnpm

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
     steps:
       - uses: actions/checkout@v5
 
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@v5
         with:
           version: 10.2.1
 
@@ -39,7 +39,7 @@ jobs:
     steps:
       - uses: actions/checkout@v5
 
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@v5
         with:
           version: 10.2.1
 
@@ -60,7 +60,7 @@ jobs:
     steps:
       - uses: actions/checkout@v5
 
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@v5
         with:
           version: 10.2.1
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,7 +32,7 @@ jobs:
     steps:
       - uses: actions/checkout@v5
 
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@v5
         with:
           version: 10.2.1
 
@@ -71,7 +71,7 @@ jobs:
     steps:
       - uses: actions/checkout@v5
 
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@v5
         with:
           version: 10.2.1
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,9 +5,6 @@ on:
     tags:
       - 'v*.*.*'
 
-env:
-  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
-
 jobs:
   create-release:
     name: Create GitHub Release
@@ -15,7 +12,7 @@ jobs:
     permissions:
       contents: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - uses: softprops/action-gh-release@v2
         with:
@@ -33,13 +30,13 @@ jobs:
       matrix:
         os: [macos-latest, windows-latest, ubuntu-latest]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - uses: pnpm/action-setup@v4
         with:
           version: 10.2.1
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v5
         with:
           node-version: 22
           cache: pnpm
@@ -72,13 +69,13 @@ jobs:
     permissions:
       contents: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - uses: pnpm/action-setup@v4
         with:
           version: 10.2.1
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v5
         with:
           node-version: 22
           cache: pnpm

--- a/README.md
+++ b/README.md
@@ -12,8 +12,48 @@ Quiz show customizável para jogar online com seus amigos. O host controla o boa
 - **Mídia** — imagens e áudio nas questões e categorias
 - **QR Code** — jogadores escaneiam e entram direto na sala, sem digitar código
 - **Acesso remoto** — tunnel automático via localtunnel, sem configuração
+- **App desktop** — versão Electron para Windows, Mac e Linux
 
-## Requisitos
+## Download
+
+Baixe o instalador mais recente na página de [Releases](https://github.com/gamazyn/responde-ai/releases):
+
+| Plataforma | Arquivo |
+|---|---|
+| Windows | `responde-ai-*-x64.exe` (instalador) |
+| macOS (Apple Silicon) | `responde-ai-*-arm64.zip` |
+| macOS (Intel) | `responde-ai-*-x64.zip` |
+| Linux | `responde-ai-*-x86_64.AppImage` |
+
+> **Nota sobre segurança:** os binários não são assinados com certificado digital pago. Veja as instruções abaixo para cada plataforma.
+
+### Windows
+
+O SmartScreen pode exibir um aviso ao abrir o instalador. Para prosseguir:
+
+1. Clique em **Mais informações**
+2. Clique em **Executar assim mesmo**
+
+### macOS
+
+O Gatekeeper bloqueará a abertura na primeira vez. Para liberar o app:
+
+```sh
+xattr -dr com.apple.quarantine /Applications/Responde\ Aí\!.app
+```
+
+Ou, alternativamente: clique com o botão direito no app → **Abrir** → **Abrir** na janela de confirmação.
+
+### Linux
+
+Torne o AppImage executável e execute diretamente:
+
+```sh
+chmod +x responde-ai-*.AppImage
+./responde-ai-*.AppImage
+```
+
+## Requisitos (modo dev)
 
 - [Node.js](https://nodejs.org) v20+
 - [pnpm](https://pnpm.io) v9+
@@ -45,6 +85,14 @@ pnpm dev
 Isso inicia o servidor (`:3000`) e o cliente (`:5173`) em paralelo.
 
 Acesse **http://localhost:5173** no browser.
+
+### App Electron em desenvolvimento
+
+Com o `pnpm dev` rodando, abra outro terminal:
+
+```bash
+pnpm electron:dev
+```
 
 ## Como jogar
 
@@ -83,7 +131,8 @@ responde-ai/
 ├── packages/
 │   ├── shared/     # Tipos TypeScript e utilitários compartilhados
 │   ├── server/     # Backend Node.js + Express + Socket.io
-│   └── client/     # Frontend React + Vite + Tailwind
+│   ├── client/     # Frontend React + Vite + Tailwind
+│   └── electron/   # App desktop (Electron + auto-updater)
 ```
 
 ## Stack
@@ -92,6 +141,7 @@ responde-ai/
 |---|---|
 | Frontend | React 18 + TypeScript + Vite + Tailwind + Framer Motion |
 | Backend | Node.js + Express + Socket.io |
+| Desktop | Electron + electron-builder + electron-updater |
 | Monorepo | pnpm workspaces + Turborepo |
 | Tunnel | localtunnel |
 
@@ -100,8 +150,10 @@ responde-ai/
 | Comando | Descrição |
 |---|---|
 | `pnpm dev` | Inicia server + client em modo dev |
+| `pnpm electron:dev` | Abre janela Electron (requer `pnpm dev` rodando) |
 | `pnpm build` | Build de produção |
 | `pnpm type-check` | Checa tipos em todos os packages |
+| `pnpm test` | Roda todos os testes |
 | `pnpm seed` | Importa os jogos de exemplo de `samples/` para `data/` |
 
 ## Licença


### PR DESCRIPTION
## Summary

- Atualiza `actions/checkout` e `actions/setup-node` para `@v5` (Node 24 nativo) nos três workflows (`ci.yml`, `build.yml`, `release.yml`)
- Remove `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24` — não funcionava para actions de terceiros; fix real é atualizar as versões
- README: nova seção **Download** com tabela de binários por plataforma e instruções de instalação (workarounds SmartScreen/Gatekeeper/AppImage) para binários sem code signing
- README: documenta `pnpm electron:dev` e `pnpm test` na tabela de scripts

## Test plan

- [x] CI passa sem warnings de Node 20 deprecated
- [x] README renderiza corretamente no GitHub

Closes #11