### PR TITLE
Fase 8.5 — Correção build Electron + tunnel remoto

### DIFF
--- a/packages/client/src/views/LobbyView.tsx
+++ b/packages/client/src/views/LobbyView.tsx
@@ -1,4 +1,4 @@
-import { useEffect } from 'react';
+import { useEffect, useState } from 'react';
 import { useNavigate, useParams } from 'react-router-dom';
 import { QRCodeSVG } from 'qrcode.react';
 import { socket } from '../socket.js';
@@ -17,12 +17,22 @@ export function LobbyView() {
     }
   }, [phase]);
 
+  // Tunnel tem prioridade: jogadores remotos são o caso principal
+  const joinUrl = tunnelUrl ?? localUrl;
+  const [copied, setCopied] = useState(false);
+
   function handleStart() {
     if (!sessionId || !hostToken) return;
     socket.emit('host:start', { sessionId, hostToken });
   }
 
-  const joinUrl = localUrl ?? tunnelUrl;
+  function handleCopyLink() {
+    if (!joinUrl || !sessionId) return;
+    navigator.clipboard.writeText(`${joinUrl}/join/${sessionId}`).then(() => {
+      setCopied(true);
+      setTimeout(() => setCopied(false), 2000);
+    });
+  }
 
   return (
     <div className="min-h-screen flex flex-col items-center justify-center p-6 relative overflow-hidden">
@@ -56,7 +66,7 @@ export function LobbyView() {
         </div>
 
         {/* QR code */}
-        {sessionId && joinUrl && (
+        {sessionId && (localUrl || tunnelUrl) && (
           <div
             className="rounded-2xl p-5 flex flex-col items-center gap-3"
             style={{
@@ -65,27 +75,58 @@ export function LobbyView() {
               boxShadow: '0 4px 16px rgba(0,0,0,0.4)',
             }}
           >
-            <div
-              className="bg-white rounded-xl p-3"
-              style={{ boxShadow: '0 4px 12px rgba(0,0,0,0.5)' }}
-            >
-              <QRCodeSVG
-                value={`${joinUrl}/join/${sessionId}`}
-                size={148}
-                bgColor="#ffffff"
-                fgColor="#1e3a5f"
-              />
-            </div>
-            <p className="text-slate-500 font-ui text-xs">Mesma rede Wi-Fi</p>
-            {tunnelUrl && (
-              <button
-                className="font-ui text-sm transition-colors"
-                style={{ color: '#E8B84B' }}
-                onMouseEnter={(e) => ((e.currentTarget as HTMLElement).style.color = '#F0C45A')}
-                onMouseLeave={(e) => ((e.currentTarget as HTMLElement).style.color = '#E8B84B')}
-                onClick={() => navigator.clipboard.writeText(`${tunnelUrl}/join/${sessionId}`)}
+            {joinUrl ? (
+              <div
+                className="bg-white rounded-xl p-3"
+                style={{ boxShadow: '0 4px 12px rgba(0,0,0,0.5)' }}
               >
-                Copiar link remoto ↗
+                <QRCodeSVG
+                  value={`${joinUrl}/join/${sessionId}`}
+                  size={148}
+                  bgColor="#ffffff"
+                  fgColor="#1e3a5f"
+                />
+              </div>
+            ) : null}
+
+            {/* Status do tunnel */}
+            {tunnelUrl ? (
+              <p className="text-slate-500 font-ui text-xs">🌐 Acesso remoto (internet)</p>
+            ) : (
+              <p className="text-slate-500 font-ui text-xs flex items-center gap-1">
+                <span
+                  className="inline-block w-2 h-2 rounded-full"
+                  style={{ background: '#E8B84B', animation: 'pulse 1.5s ease-in-out infinite' }}
+                />
+                Conectando tunnel...
+              </p>
+            )}
+
+            {/* Botão copiar — tunnel quando disponível, Wi-Fi como fallback */}
+            <button
+              className="font-ui text-sm transition-colors"
+              style={{ color: copied ? '#4ade80' : '#E8B84B' }}
+              onMouseEnter={(e) => { if (!copied) (e.currentTarget as HTMLElement).style.color = '#F0C45A' }}
+              onMouseLeave={(e) => { if (!copied) (e.currentTarget as HTMLElement).style.color = '#E8B84B' }}
+              onClick={handleCopyLink}
+            >
+              {copied
+                ? '✓ Link copiado!'
+                : tunnelUrl
+                  ? 'Copiar link remoto ↗'
+                  : 'Copiar link Wi-Fi ↗'}
+            </button>
+
+            {/* Link Wi-Fi local como fallback visível quando tunnel ativo */}
+            {tunnelUrl && localUrl && (
+              <button
+                className="font-ui text-xs transition-colors"
+                style={{ color: '#475569' }}
+                onMouseEnter={(e) => ((e.currentTarget as HTMLElement).style.color = '#64748b')}
+                onMouseLeave={(e) => ((e.currentTarget as HTMLElement).style.color = '#475569')}
+                onClick={() => navigator.clipboard.writeText(`${localUrl}/join/${sessionId}`)}
+              >
+                Copiar link Wi-Fi (mesma rede)
               </button>
             )}
           </div>

--- a/packages/electron/esbuild.config.mjs
+++ b/packages/electron/esbuild.config.mjs
@@ -1,0 +1,13 @@
+import * as esbuild from 'esbuild'
+
+await esbuild.build({
+  entryPoints: ['../server/dist/server.js'],
+  bundle: true,
+  platform: 'node',
+  format: 'esm',
+  outfile: 'resources/server-bundle.mjs',
+  external: ['fsevents', 'bufferutil', 'utf-8-validate', 'canvas'],
+  banner: {
+    js: "import { createRequire } from 'module'; const require = createRequire(import.meta.url);",
+  },
+})

--- a/packages/electron/package.json
+++ b/packages/electron/package.json
@@ -6,7 +6,7 @@
   "main": "dist/main.js",
   "scripts": {
     "dev": "electron .",
-    "build:bundle": "esbuild ../server/dist/server.js --bundle --platform=node --format=esm --outfile=resources/server-bundle.mjs --external:fsevents --external:bufferutil --external:utf-8-validate --external:canvas",
+    "build:bundle": "node esbuild.config.mjs",
     "build:tsc": "tsc",
     "build": "pnpm build:bundle && pnpm build:tsc",
     "pack": "electron-builder --dir",

--- a/packages/electron/package.json
+++ b/packages/electron/package.json
@@ -25,7 +25,7 @@
     "@types/node": "^22.0.0",
     "@vitest/coverage-v8": "^4.1.4",
     "esbuild": "^0.25.0",
-    "electron": "^35.0.0",
+    "electron": "^38.0.0",
     "electron-builder": "^25.0.0",
     "typescript": "^5.7.2",
     "vitest": "^4.1.4"

--- a/packages/electron/src/main.ts
+++ b/packages/electron/src/main.ts
@@ -1,4 +1,4 @@
-import { app, BrowserWindow, shell } from 'electron'
+import { app, BrowserWindow, shell, dialog } from 'electron'
 import { initUpdater } from './updater.js'
 import { createServer as createNetServer } from 'net'
 import { networkInterfaces } from 'os'
@@ -60,7 +60,10 @@ async function startProductionServer(): Promise<number> {
   const localIp = getLocalIp()
   if (localIp) setLocalUrl(`http://${localIp}:${port}`)
 
-  await new Promise<void>((resolve) => httpServer.listen(port, resolve))
+  await new Promise<void>((resolve, reject) => {
+    httpServer.listen(port, resolve)
+    httpServer.once('error', reject)
+  })
   return port
 }
 
@@ -92,7 +95,10 @@ async function createWindow(): Promise<void> {
 }
 
 app.whenReady().then(() => {
-  createWindow()
+  createWindow().catch((err: Error) => {
+    dialog.showErrorBox('Falha ao iniciar', err.message)
+    app.quit()
+  })
   initUpdater()
 })
 

--- a/packages/electron/src/main.ts
+++ b/packages/electron/src/main.ts
@@ -1,4 +1,4 @@
-import { app, BrowserWindow, shell, dialog } from 'electron'
+import { app, BrowserWindow, shell, dialog, Menu } from 'electron'
 import { initUpdater } from './updater.js'
 import { createServer as createNetServer } from 'net'
 import { networkInterfaces } from 'os'
@@ -47,15 +47,16 @@ async function startProductionServer(): Promise<number> {
     ? path.join(process.resourcesPath, 'server-bundle.mjs')
     : path.join(__dirname, '../resources/server-bundle.mjs')
 
-  const { createApp } = (await import(pathToFileURL(serverBundlePath).href)) as {
+  const { createApp, startTunnel } = (await import(pathToFileURL(serverBundlePath).href)) as {
     createApp: () => {
       httpServer: import('http').Server
       setLocalUrl: (url: string) => void
       setTunnelUrl: (url: string) => void
     }
+    startTunnel: (port: number) => Promise<string | null>
   }
 
-  const { httpServer, setLocalUrl } = createApp()
+  const { httpServer, setLocalUrl, setTunnelUrl } = createApp()
 
   const localIp = getLocalIp()
   if (localIp) setLocalUrl(`http://${localIp}:${port}`)
@@ -64,6 +65,12 @@ async function startProductionServer(): Promise<number> {
     httpServer.listen(port, resolve)
     httpServer.once('error', reject)
   })
+
+  // Inicia tunnel em background — não bloqueia abertura da janela
+  startTunnel(port).then((tunnelUrl) => {
+    if (tunnelUrl) setTunnelUrl(tunnelUrl)
+  }).catch(() => { /* tunnel opcional, falha silenciosa */ })
+
   return port
 }
 
@@ -95,6 +102,7 @@ async function createWindow(): Promise<void> {
 }
 
 app.whenReady().then(() => {
+  Menu.setApplicationMenu(null)
   createWindow().catch((err: Error) => {
     dialog.showErrorBox('Falha ao iniciar', err.message)
     app.quit()

--- a/packages/server/src/server.ts
+++ b/packages/server/src/server.ts
@@ -3,6 +3,7 @@ import { createServer, request as httpRequest } from 'http';
 import { Server } from 'socket.io';
 import helmet from 'helmet';
 import cors from 'cors';
+export { startTunnel } from './tunnel.js';
 import { resolve } from 'path';
 import type { ServerToClientEvents, ClientToServerEvents } from '@responde-ai/shared';
 import { PORT, CLIENT_URL, GAMES_DIR, NODE_ENV } from './config.js';

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -110,8 +110,8 @@ importers:
         specifier: ^4.1.4
         version: 4.1.4(vitest@4.1.4)
       electron:
-        specifier: ^35.0.0
-        version: 35.7.5
+        specifier: ^38.0.0
+        version: 38.8.6
       electron-builder:
         specifier: ^25.0.0
         version: 25.1.8(electron-builder-squirrel-windows@25.1.8)
@@ -1712,8 +1712,8 @@ packages:
   electron-updater@6.8.3:
     resolution: {integrity: sha512-Z6sgw3jgbikWKXei1ENdqFOxBP0WlXg3TtKfz0rgw2vIZFJUyI4pD7ZN7jrkm7EoMK+tcm/qTnPUdqfZukBlBQ==}
 
-  electron@35.7.5:
-    resolution: {integrity: sha512-dnL+JvLraKZl7iusXTVTGYs10TKfzUi30uEDTqsmTm0guN9V2tbOjTzyIZbh9n3ygUjgEYyo+igAwMRXIi3IPw==}
+  electron@38.8.6:
+    resolution: {integrity: sha512-lyBhcVi9QYAZL6FO6r5twAWAjWnYomo3iVDvrb5SJZlq928BGemHOKG0tPIq41NOLaCu9f3XdEEjMkjQPjprRg==}
     engines: {node: '>= 12.20.55'}
     hasBin: true
 
@@ -5025,7 +5025,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  electron@35.7.5:
+  electron@38.8.6:
     dependencies:
       '@electron/get': 2.0.3
       '@types/node': 22.19.17


### PR DESCRIPTION
## O que muda

### Bug fix: tela branca no app packaged (closes #16)
- Bundling do servidor com esbuild gerava `Dynamic require of "path" is not supported` em runtime
- Fix: injetar `createRequire` via banner do esbuild para que o shim CJS funcione em ESM

### Bump Electron 35 → 38
- Suporte a plataformas mais recentes

### Tunnel remoto automático
- App inicia `localtunnel` em background após o servidor subir
- Jogadores remotos (fora da rede local) conseguem entrar via link público
- `startTunnel` exportado do server bundle para uso no main process

### UX do Lobby
- QR code prioriza URL do tunnel (caso de uso principal: jogadores remotos)
- Indicador "Conectando tunnel..." com animação pulse enquanto tunnel carrega
- Botão "Copiar link remoto" sempre visível; fallback para link Wi-Fi enquanto tunnel conecta
- Botão secundário discreto para copiar link Wi-Fi quando ambos os links estão disponíveis
- Menu nativo do Electron removido (File / View / Help)

## Testado
- ✅ Windows `.exe` (portable x64) — app abre, servidor inicia, lobby exibe QR
- ✅ Fase 8 (modos de jogo) presente no build
- ⚠️ macOS 26 (Tahoe beta) — crash `EXC_BREAKPOINT` no Electron, incompatibilidade upstream, sem fix disponível