### PR TITLE
chore: bump version to 1.0.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "responde-ai",
-  "version": "0.0.1",
+  "version": "1.0.2",
   "private": true,
   "scripts": {
     "dev": "turbo run dev --parallel",

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@responde-ai/client",
-  "version": "0.0.1",
+  "version": "1.0.2",
   "private": true,
   "type": "module",
   "scripts": {

--- a/packages/electron/package.json
+++ b/packages/electron/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@responde-ai/electron",
-  "version": "0.0.1",
+  "version": "1.0.2",
   "private": true,
   "type": "module",
   "main": "dist/main.js",

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@responde-ai/server",
-  "version": "0.0.1",
+  "version": "1.0.2",
   "private": true,
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@responde-ai/shared",
-  "version": "0.0.1",
+  "version": "1.0.2",
   "private": true,
   "type": "module",
   "main": "./dist/index.js",


### PR DESCRIPTION
## Summary
- Bump all workspace packages from `0.0.1` → `1.0.2` para sincronizar com as tags do repositório
- Patch release alinhado ao conteúdo da Fase 8.5 (Electron fix + tunnel remoto)

## Checklist release
- [x] PR aprovado e mergeado na `main`
- [x] Tag `v1.0.2` criada apontando para main