### PR TITLE
fix(electron): set releaseType release para upload em release já publicada

### DIFF
--- a/packages/electron/electron-builder.yml
+++ b/packages/electron/electron-builder.yml
@@ -6,6 +6,7 @@ publish:
   provider: github
   owner: gamazyn
   repo: responde-ai
+  releaseType: release
 
 artifactName: "responde-ai-${version}-${arch}.${ext}"
 


### PR DESCRIPTION
## Problema
electron-builder tenta publicar como `draft` por padrão. A release já existe como `release` (criada pelo `softprops/action-gh-release`). Conflito → todos os uploads são pulados.

## Fix
Adiciona `releaseType: release` no `electron-builder.yml` para alinhar com a release já publicada.

## Próximo passo
Após merge: re-acionar os jobs Electron na run `v1.0.2` ou deletar/recriar a tag.