### PR TITLE
chore: bump version to 1.1.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "buzze",
-  "version": "1.0.2",
+  "version": "1.1.0",
   "private": true,
   "scripts": {
     "dev": "turbo run dev --parallel",

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@buzze/client",
-  "version": "1.0.2",
+  "version": "1.1.0",
   "private": true,
   "type": "module",
   "scripts": {

--- a/packages/electron/package.json
+++ b/packages/electron/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@buzze/electron",
-  "version": "1.0.2",
+  "version": "1.1.0",
   "private": true,
   "type": "module",
   "main": "dist/main.js",

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@buzze/server",
-  "version": "1.0.2",
+  "version": "1.1.0",
   "private": true,
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@buzze/shared",
-  "version": "1.0.2",
+  "version": "1.1.0",
   "private": true,
   "type": "module",
   "main": "./dist/index.js",


### PR DESCRIPTION
## Release v1.1.0

Bump de versão **minor** para a release com nova identidade visual e i18n.

### O que entra nesta release

- Rebranding completo para **buzze.io** (era Responde Aí)
- Redesign visual de todas as views — design system com tokens violet/fuchsia, Syne/DM Sans/JetBrains Mono
- **i18n completo** — PT-BR, EN e ES com detecção automática de idioma
- Novo tipo de questão: **Speed Round**
- `README.md` reescrito em inglês com seção Download por plataforma

### Próximo passo

Após merge: criar tag `v1.1.0` para acionar o build do Electron.