### PR TITLE
refactor: reduce game complexity and split client bundle

### DIFF
--- a/packages/client/src/App.tsx
+++ b/packages/client/src/App.tsx
@@ -1,26 +1,34 @@
+import { lazy, Suspense } from 'react';
 import { BrowserRouter, Routes, Route, Navigate } from 'react-router-dom';
-import { LandingView } from './views/LandingView.js';
-import { HostSetupView } from './views/HostSetupView.js';
-import { LobbyView } from './views/LobbyView.js';
-import { HostBoardView } from './views/host/HostBoardView.js';
-import { PlayerGameView } from './views/player/PlayerGameView.js';
-import { EditorView } from './views/editor/EditorView.js';
-import { JoinView } from './views/JoinView.js';
+
+const LandingView = lazy(() => import('./views/LandingView.js').then((module) => ({ default: module.LandingView })));
+const HostSetupView = lazy(() => import('./views/HostSetupView.js').then((module) => ({ default: module.HostSetupView })));
+const LobbyView = lazy(() => import('./views/LobbyView.js').then((module) => ({ default: module.LobbyView })));
+const HostBoardView = lazy(() => import('./views/host/HostBoardView.js').then((module) => ({ default: module.HostBoardView })));
+const PlayerGameView = lazy(() => import('./views/player/PlayerGameView.js').then((module) => ({ default: module.PlayerGameView })));
+const EditorView = lazy(() => import('./views/editor/EditorView.js').then((module) => ({ default: module.EditorView })));
+const JoinView = lazy(() => import('./views/JoinView.js').then((module) => ({ default: module.JoinView })));
+
+function RouteFallback() {
+  return <div style={{ minHeight: '100vh', background: '#07060f' }} />;
+}
 
 export default function App() {
   return (
     <BrowserRouter>
-      <Routes>
-        <Route path="/" element={<LandingView />} />
-        <Route path="/host" element={<HostSetupView />} />
-        <Route path="/host/:sessionId" element={<LobbyView />} />
-        <Route path="/host/:sessionId/board" element={<HostBoardView />} />
-        <Route path="/game/:sessionId/player" element={<PlayerGameView />} />
-        <Route path="/join/:sessionId" element={<JoinView />} />
-        <Route path="/editor" element={<EditorView />} />
-        <Route path="/editor/:gameId" element={<EditorView />} />
-        <Route path="*" element={<Navigate to="/" replace />} />
-      </Routes>
+      <Suspense fallback={<RouteFallback />}>
+        <Routes>
+          <Route path="/" element={<LandingView />} />
+          <Route path="/host" element={<HostSetupView />} />
+          <Route path="/host/:sessionId" element={<LobbyView />} />
+          <Route path="/host/:sessionId/board" element={<HostBoardView />} />
+          <Route path="/game/:sessionId/player" element={<PlayerGameView />} />
+          <Route path="/join/:sessionId" element={<JoinView />} />
+          <Route path="/editor" element={<EditorView />} />
+          <Route path="/editor/:gameId" element={<EditorView />} />
+          <Route path="*" element={<Navigate to="/" replace />} />
+        </Routes>
+      </Suspense>
     </BrowserRouter>
   );
 }

--- a/packages/client/src/components/media/SyncedAudioPlayer.tsx
+++ b/packages/client/src/components/media/SyncedAudioPlayer.tsx
@@ -1,0 +1,84 @@
+import { useCallback, useRef, useState } from 'react';
+
+interface SyncedAudioPlayerProps {
+  src: string;
+  audioRef: (el: HTMLAudioElement | null) => void;
+  onPlay: () => void;
+  onPause: () => void;
+  onSeeked: () => void;
+}
+
+export function SyncedAudioPlayer({
+  src,
+  audioRef,
+  onPlay,
+  onPause,
+  onSeeked,
+}: SyncedAudioPlayerProps) {
+  const elRef = useRef<HTMLAudioElement | null>(null);
+  const [playing, setPlaying] = useState(false);
+  const [current, setCurrent] = useState(0);
+  const [duration, setDuration] = useState(0);
+
+  const combinedRef = useCallback((el: HTMLAudioElement | null) => {
+    elRef.current = el;
+    audioRef(el);
+  }, [audioRef]);
+
+  const progress = duration > 0 ? (current / duration) * 100 : 0;
+
+  function fmt(seconds: number) {
+    const minutes = Math.floor(seconds / 60);
+    const secs = Math.floor(seconds % 60);
+    return `${minutes}:${secs.toString().padStart(2, '0')}`;
+  }
+
+  return (
+    <div
+      className="w-full rounded-xl px-4 py-3 flex items-center gap-3"
+      style={{ background: 'rgba(255,255,255,0.05)', border: '1px solid rgba(255,255,255,0.08)' }}
+    >
+      <audio
+        ref={combinedRef}
+        src={src}
+        onPlay={() => { setPlaying(true); onPlay(); }}
+        onPause={() => { setPlaying(false); onPause(); }}
+        onSeeked={onSeeked}
+        onTimeUpdate={(event) => setCurrent((event.target as HTMLAudioElement).currentTime)}
+        onLoadedMetadata={(event) => setDuration((event.target as HTMLAudioElement).duration)}
+      />
+      <button
+        className="flex-shrink-0 w-9 h-9 rounded-full flex items-center justify-center transition-all"
+        style={{ background: 'rgba(124,58,237,0.8)' }}
+        onMouseEnter={(event) => { (event.currentTarget as HTMLElement).style.background = '#7c3aed'; }}
+        onMouseLeave={(event) => { (event.currentTarget as HTMLElement).style.background = 'rgba(124,58,237,0.8)'; }}
+        onClick={() => { elRef.current?.paused ? elRef.current.play() : elRef.current?.pause(); }}
+      >
+        {playing
+          ? <span style={{ color: '#fff', fontSize: 12 }}>||</span>
+          : <span style={{ color: '#fff', fontSize: 13, paddingLeft: 2 }}>▶</span>}
+      </button>
+
+      <div className="flex-1 flex flex-col gap-1.5 min-w-0">
+        <div className="flex items-center justify-between">
+          <span className="font-mono text-[9px] uppercase tracking-widest" style={{ color: '#6b6390' }}>ÁUDIO DA DICA</span>
+          <span className="font-mono text-[9px] uppercase tracking-widest" style={{ color: '#3a3558' }}>HOST SYNC</span>
+        </div>
+        <div
+          className="relative w-full h-1 rounded-full cursor-pointer"
+          style={{ background: 'rgba(255,255,255,0.1)' }}
+          onClick={(event) => {
+            if (!elRef.current || !duration) return;
+            const rect = event.currentTarget.getBoundingClientRect();
+            elRef.current.currentTime = ((event.clientX - rect.left) / rect.width) * duration;
+          }}
+        >
+          <div className="absolute inset-y-0 left-0 rounded-full" style={{ width: `${progress}%`, background: '#7c3aed' }} />
+        </div>
+        <span className="font-mono text-[10px]" style={{ color: '#6b6390' }}>
+          {fmt(current)} / {fmt(duration)}
+        </span>
+      </div>
+    </div>
+  );
+}

--- a/packages/client/src/components/question/TimerCircle.tsx
+++ b/packages/client/src/components/question/TimerCircle.tsx
@@ -1,0 +1,45 @@
+interface TimerCircleProps {
+  remainingMs: number;
+  totalMs: number;
+  isPaused: boolean;
+}
+
+export function TimerCircle({ remainingMs, totalMs, isPaused }: TimerCircleProps) {
+  const radius = 28;
+  const circumference = 2 * Math.PI * radius;
+  const fraction = totalMs > 0 ? Math.max(0, remainingMs / totalMs) : 0;
+  const offset = circumference * (1 - fraction);
+  const seconds = Math.ceil(remainingMs / 1000);
+  const color = isPaused ? '#6b6390' : fraction > 0.4 ? '#c084fc' : fraction > 0.2 ? '#ffc857' : '#ff4d6d';
+
+  return (
+    <div className="flex flex-col items-center gap-1 flex-shrink-0">
+      <span className="font-mono text-[9px] uppercase tracking-widest" style={{ color: '#6b6390' }}>TIMER</span>
+      <svg width={72} height={72} viewBox="0 0 72 72">
+        <circle cx={36} cy={36} r={radius} fill="none" stroke="rgba(255,255,255,0.07)" strokeWidth={4} />
+        <circle
+          cx={36}
+          cy={36}
+          r={radius}
+          fill="none"
+          stroke={color}
+          strokeWidth={4}
+          strokeLinecap="round"
+          strokeDasharray={circumference}
+          strokeDashoffset={offset}
+          transform="rotate(-90 36 36)"
+          style={{ transition: isPaused ? 'none' : 'stroke-dashoffset 0.5s linear, stroke 0.3s' }}
+        />
+        <text
+          x={36}
+          y={41}
+          textAnchor="middle"
+          fill={color}
+          style={{ fontFamily: 'JetBrains Mono, monospace', fontSize: 18, fontWeight: 700 }}
+        >
+          {seconds}
+        </text>
+      </svg>
+    </div>
+  );
+}

--- a/packages/client/src/components/scores/Scoreboard.tsx
+++ b/packages/client/src/components/scores/Scoreboard.tsx
@@ -1,6 +1,7 @@
 import { motion, AnimatePresence } from 'framer-motion';
 import { useTranslation } from 'react-i18next';
 import type { Player } from '@buzze/shared';
+import { PlayerAvatar } from '../ui/PlayerAvatar.js';
 
 interface Props {
   players: Player[];
@@ -13,25 +14,6 @@ const RANK_STYLES = [
   { border: '#94a3b8', bg: 'rgba(148,163,184,0.06)', glow: 'none' },
   { border: '#f97316', bg: 'rgba(249,115,22,0.06)', glow: 'none' },
 ];
-
-function PlayerAvatar({ name, color, size = 28 }: { name: string; color: string; size?: number }) {
-  return (
-    <div
-      className="flex-shrink-0 flex items-center justify-center rounded-full font-display font-bold"
-      style={{
-        width: size,
-        height: size,
-        background: color,
-        color: '#07060f',
-        fontSize: Math.round(size * 0.43),
-        lineHeight: 1,
-        boxShadow: `0 0 8px ${color}55`,
-      }}
-    >
-      {name.charAt(0).toUpperCase()}
-    </div>
-  );
-}
 
 export function Scoreboard({ players, myId, compact = false }: Props) {
   const { t } = useTranslation();

--- a/packages/client/src/components/ui/PlayerAvatar.tsx
+++ b/packages/client/src/components/ui/PlayerAvatar.tsx
@@ -1,0 +1,32 @@
+interface PlayerAvatarProps {
+  name: string;
+  color: string;
+  size?: number;
+  textColor?: string;
+  className?: string;
+}
+
+export function PlayerAvatar({
+  name,
+  color,
+  size = 32,
+  textColor = '#07060f',
+  className = '',
+}: PlayerAvatarProps) {
+  return (
+    <div
+      className={`flex-shrink-0 flex items-center justify-center rounded-full font-display font-bold ${className}`}
+      style={{
+        width: size,
+        height: size,
+        background: color,
+        color: textColor,
+        fontSize: Math.round(size * 0.43),
+        lineHeight: 1,
+        boxShadow: `0 0 8px ${color}55`,
+      }}
+    >
+      {name.charAt(0).toUpperCase()}
+    </div>
+  );
+}

--- a/packages/client/src/hooks/useHostActions.ts
+++ b/packages/client/src/hooks/useHostActions.ts
@@ -1,0 +1,56 @@
+import { useCallback } from 'react';
+import { socket } from '../socket.js';
+
+interface HostActionContext {
+  sessionId: string;
+  hostToken: string;
+}
+
+export function useHostActions({ sessionId, hostToken }: HostActionContext) {
+  const withHost = useCallback(
+    <T extends object>(payload: T) => ({ sessionId, hostToken, ...payload }),
+    [hostToken, sessionId],
+  );
+
+  return {
+    start: useCallback(() => {
+      socket.emit('host:start', withHost({}));
+    }, [withHost]),
+    selectQuestion: useCallback((categoryId: string, questionId: string) => {
+      socket.emit('host:selectQuestion', withHost({ categoryId, questionId }));
+    }, [withHost]),
+    judge: useCallback((playerId: string, correct: boolean) => {
+      socket.emit('host:judge', withHost({ playerId, correct }));
+    }, [withHost]),
+    skipPlayer: useCallback((playerId: string) => {
+      socket.emit('host:skipPlayer', withHost({ playerId }));
+    }, [withHost]),
+    clearQuestion: useCallback((revealAnswer: boolean) => {
+      socket.emit(revealAnswer ? 'host:clearQuestion' : 'host:clearQuestionNoReveal', withHost({}));
+    }, [withHost]),
+    timerControl: useCallback((action: 'pause' | 'resume' | 'extend' | 'set', seconds?: number) => {
+      socket.emit('host:timerControl', withHost({ action, seconds }));
+    }, [withHost]),
+    continueBoard: useCallback(() => {
+      socket.emit('host:continueBoard', withHost({}));
+    }, [withHost]),
+    assignDouble: useCallback((playerId: string) => {
+      socket.emit('host:assignDouble', withHost({ playerId }));
+    }, [withHost]),
+    setChallenge: useCallback((challengedId: string) => {
+      socket.emit('host:setChallenge', withHost({ challengedId }));
+    }, [withHost]),
+    revealFinal: useCallback((playerId: string, isCorrect: boolean) => {
+      socket.emit('host:revealFinal', withHost({ playerId, isCorrect }));
+    }, [withHost]),
+    startFinal: useCallback(() => {
+      socket.emit('host:startFinal', withHost({}));
+    }, [withHost]),
+    endGame: useCallback(() => {
+      socket.emit('host:endGame', withHost({}));
+    }, [withHost]),
+    audioControl: useCallback((action: 'play' | 'pause' | 'seek', currentTime: number) => {
+      socket.emit('host:audioControl', withHost({ action, currentTime }));
+    }, [withHost]),
+  };
+}

--- a/packages/client/src/hooks/usePlayerActions.ts
+++ b/packages/client/src/hooks/usePlayerActions.ts
@@ -1,0 +1,24 @@
+import { useCallback } from 'react';
+import { socket } from '../socket.js';
+
+interface PlayerActionContext {
+  sessionId: string;
+  playerId: string;
+}
+
+export function usePlayerActions({ sessionId, playerId }: PlayerActionContext) {
+  return {
+    buzz: useCallback(() => {
+      socket.emit('player:buzz', { sessionId, playerId });
+    }, [playerId, sessionId]),
+    submitFinalWager: useCallback((amount: number) => {
+      socket.emit('player:finalWager', { sessionId, playerId, amount });
+    }, [playerId, sessionId]),
+    submitDoubleWager: useCallback((amount: number) => {
+      socket.emit('player:doubleWager', { sessionId, playerId, amount });
+    }, [playerId, sessionId]),
+    submitSpeedAnswer: useCallback((answer: string) => {
+      socket.emit('player:speedAnswer', { sessionId, answer });
+    }, [sessionId]),
+  };
+}

--- a/packages/client/src/views/LobbyView.tsx
+++ b/packages/client/src/views/LobbyView.tsx
@@ -5,29 +5,12 @@ import { useTranslation } from 'react-i18next';
 import { socket } from '../socket.js';
 import { useGameStore } from '../store/gameStore.js';
 import { useSocketEvents } from '../hooks/useSocketEvents.js';
+import { useHostActions } from '../hooks/useHostActions.js';
 import { BuzzeLogo } from '../components/ui/BuzzeLogo.js';
+import { PlayerAvatar } from '../components/ui/PlayerAvatar.js';
 import type { GameConfig } from '@buzze/shared';
 
 const MAX_LOBBY_SLOTS = 8;
-
-/* ─── Avatar ──────────────────────────────────────────────── */
-function Avatar({ name, color }: { name: string; color: string }) {
-  return (
-    <div
-      style={{
-        width: 36, height: 36, borderRadius: '50%',
-        background: color,
-        display: 'flex', alignItems: 'center', justifyContent: 'center',
-        fontFamily: 'Syne, system-ui, sans-serif',
-        fontWeight: 800, fontSize: 14, color: '#fff',
-        flexShrink: 0,
-        boxShadow: `0 0 8px ${color}80`,
-      }}
-    >
-      {name[0]?.toUpperCase()}
-    </div>
-  );
-}
 
 /* ─── CopyButton ──────────────────────────────────────────── */
 function CopyButton({ text, label, labelDone }: { text: string; label: string; labelDone: string }) {
@@ -64,6 +47,7 @@ export function LobbyView() {
   const { players, phase, hostToken, tunnelUrl, localUrl, isHost } = useGameStore();
   const [gameConfig, setGameConfig] = useState<Omit<GameConfig, 'finalChallengeAnswer'> | null>(null);
   useSocketEvents();
+  const hostActions = useHostActions({ sessionId: sessionId ?? '', hostToken: hostToken ?? '' });
 
   useEffect(() => {
     if (state?.gameId) {
@@ -82,7 +66,7 @@ export function LobbyView() {
 
   function handleStart() {
     if (!sessionId || !hostToken) return;
-    socket.emit('host:start', { sessionId, hostToken });
+    hostActions.start();
   }
 
   function handleLeave() {
@@ -425,7 +409,7 @@ export function LobbyView() {
                   borderBottom: '1px solid rgba(255,255,255,0.04)',
                 }}
               >
-                <Avatar name={p.name} color={p.avatarColor} />
+                <PlayerAvatar name={p.name} color={p.avatarColor} size={36} textColor="#fff" />
                 <span style={{
                   fontFamily: 'DM Sans, sans-serif', fontWeight: 500,
                   fontSize: 15, color: '#f0ecff', flex: 1,

--- a/packages/client/src/views/host/HostBoardView.tsx
+++ b/packages/client/src/views/host/HostBoardView.tsx
@@ -5,136 +5,15 @@ import { useTranslation } from 'react-i18next';
 import { socket } from '../../socket.js';
 import { useGameStore } from '../../store/gameStore.js';
 import { useSocketEvents } from '../../hooks/useSocketEvents.js';
+import { useHostActions } from '../../hooks/useHostActions.js';
 import { GameBoard } from '../../components/board/GameBoard.js';
 import { Scoreboard } from '../../components/scores/Scoreboard.js';
 import { ConfirmModal } from '../../components/ui/ConfirmModal.js';
 import { BuzzeLogo } from '../../components/ui/BuzzeLogo.js';
 import { QuestionTimer } from '../../components/question/QuestionTimer.js';
-
-// ─── Timer circle ────────────────────────────────────────────────────────────
-function TimerCircle({ remainingMs, totalMs, isPaused }: { remainingMs: number; totalMs: number; isPaused: boolean }) {
-  const r = 28;
-  const circ = 2 * Math.PI * r;
-  const frac = totalMs > 0 ? Math.max(0, remainingMs / totalMs) : 0;
-  const offset = circ * (1 - frac);
-  const secs = Math.ceil(remainingMs / 1000);
-  const color = isPaused ? '#6b6390' : frac > 0.4 ? '#c084fc' : frac > 0.2 ? '#ffc857' : '#ff4d6d';
-  return (
-    <div className="flex flex-col items-center gap-1 flex-shrink-0">
-      <span className="font-mono text-[9px] uppercase tracking-widest" style={{ color: '#6b6390' }}>TIMER</span>
-      <svg width={72} height={72} viewBox="0 0 72 72">
-        <circle cx={36} cy={36} r={r} fill="none" stroke="rgba(255,255,255,0.07)" strokeWidth={4} />
-        <circle
-          cx={36} cy={36} r={r} fill="none"
-          stroke={color} strokeWidth={4}
-          strokeLinecap="round"
-          strokeDasharray={circ}
-          strokeDashoffset={offset}
-          transform="rotate(-90 36 36)"
-          style={{ transition: isPaused ? 'none' : 'stroke-dashoffset 0.5s linear, stroke 0.3s' }}
-        />
-        <text x={36} y={41} textAnchor="middle" fill={color}
-          style={{ fontFamily: 'JetBrains Mono, monospace', fontSize: 18, fontWeight: 700 }}>
-          {secs}
-        </text>
-      </svg>
-    </div>
-  );
-}
-
-// ─── Custom Audio Player ──────────────────────────────────────────────────────
-function AudioPlayer({
-  src, audioRef, onPlay, onPause, onSeeked,
-}: {
-  src: string;
-  audioRef: (el: HTMLAudioElement | null) => void;
-  onPlay: () => void;
-  onPause: () => void;
-  onSeeked: () => void;
-}) {
-  const elRef = useRef<HTMLAudioElement | null>(null);
-  const [playing, setPlaying] = useState(false);
-  const [current, setCurrent] = useState(0);
-  const [duration, setDuration] = useState(0);
-
-  const combinedRef = useCallback((el: HTMLAudioElement | null) => {
-    elRef.current = el;
-    audioRef(el);
-  }, [audioRef]);
-
-  function fmt(s: number) {
-    const m = Math.floor(s / 60);
-    const sec = Math.floor(s % 60);
-    return `${m}:${sec.toString().padStart(2, '0')}`;
-  }
-
-  const progress = duration > 0 ? (current / duration) * 100 : 0;
-
-  return (
-    <div
-      className="w-full rounded-xl px-4 py-3 flex items-center gap-3"
-      style={{ background: 'rgba(255,255,255,0.05)', border: '1px solid rgba(255,255,255,0.08)' }}
-    >
-      <audio
-        ref={combinedRef}
-        src={src}
-        onPlay={() => { setPlaying(true); onPlay(); }}
-        onPause={() => { setPlaying(false); onPause(); }}
-        onSeeked={onSeeked}
-        onTimeUpdate={(e) => setCurrent((e.target as HTMLAudioElement).currentTime)}
-        onLoadedMetadata={(e) => setDuration((e.target as HTMLAudioElement).duration)}
-      />
-      {/* Play/Pause */}
-      <button
-        className="flex-shrink-0 w-9 h-9 rounded-full flex items-center justify-center transition-all"
-        style={{ background: 'rgba(124,58,237,0.8)' }}
-        onMouseEnter={(e) => { (e.currentTarget as HTMLElement).style.background = '#7c3aed'; }}
-        onMouseLeave={(e) => { (e.currentTarget as HTMLElement).style.background = 'rgba(124,58,237,0.8)'; }}
-        onClick={() => { elRef.current?.paused ? elRef.current.play() : elRef.current?.pause(); }}
-      >
-        {playing
-          ? <span style={{ color: '#fff', fontSize: 12 }}>❚❚</span>
-          : <span style={{ color: '#fff', fontSize: 13, paddingLeft: 2 }}>▶</span>}
-      </button>
-
-      <div className="flex-1 flex flex-col gap-1.5 min-w-0">
-        {/* Labels */}
-        <div className="flex items-center justify-between">
-          <span className="font-mono text-[9px] uppercase tracking-widest" style={{ color: '#6b6390' }}>ÁUDIO DA DICA</span>
-          <span className="font-mono text-[9px] uppercase tracking-widest" style={{ color: '#3a3558' }}>HOST SYNC</span>
-        </div>
-        {/* Progress bar */}
-        <div
-          className="relative w-full h-1 rounded-full cursor-pointer"
-          style={{ background: 'rgba(255,255,255,0.1)' }}
-          onClick={(e) => {
-            if (!elRef.current || !duration) return;
-            const rect = e.currentTarget.getBoundingClientRect();
-            elRef.current.currentTime = ((e.clientX - rect.left) / rect.width) * duration;
-          }}
-        >
-          <div className="absolute inset-y-0 left-0 rounded-full" style={{ width: `${progress}%`, background: '#7c3aed' }} />
-        </div>
-        {/* Time */}
-        <span className="font-mono text-[10px]" style={{ color: '#6b6390' }}>
-          {fmt(current)} / {fmt(duration)}
-        </span>
-      </div>
-    </div>
-  );
-}
-
-// ─── Player Avatar (small) ────────────────────────────────────────────────────
-function Avatar({ name, color, size = 32 }: { name: string; color: string; size?: number }) {
-  return (
-    <div
-      className="flex-shrink-0 flex items-center justify-center rounded-full font-display font-bold"
-      style={{ width: size, height: size, background: color, color: '#07060f', fontSize: Math.round(size * 0.43), lineHeight: 1, boxShadow: `0 0 8px ${color}55` }}
-    >
-      {name.charAt(0).toUpperCase()}
-    </div>
-  );
-}
+import { TimerCircle } from '../../components/question/TimerCircle.js';
+import { SyncedAudioPlayer } from '../../components/media/SyncedAudioPlayer.js';
+import { PlayerAvatar as Avatar } from '../../components/ui/PlayerAvatar.js';
 
 // ─── Main Component ───────────────────────────────────────────────────────────
 export function HostBoardView() {
@@ -149,6 +28,7 @@ export function HostBoardView() {
     reset: resetGame,
   } = useGameStore();
   useSocketEvents();
+  const hostActions = useHostActions({ sessionId: sessionId ?? '', hostToken: hostToken ?? '' });
 
   const [showEndConfirm, setShowEndConfirm] = useState(false);
   const [showLeaveConfirm, setShowLeaveConfirm] = useState(false);
@@ -161,7 +41,7 @@ export function HostBoardView() {
 
   function emitAudio(action: 'play' | 'pause' | 'seek') {
     if (!audioRef.current || !sessionId || !hostToken) return;
-    socket.emit('host:audioControl', { sessionId, hostToken, action, currentTime: audioRef.current.currentTime });
+    hostActions.audioControl(action, audioRef.current.currentTime);
   }
 
   if (!gameConfig || !sessionId || !hostToken) return null;
@@ -176,38 +56,34 @@ export function HostBoardView() {
   const allWagered = totalWagered >= totalPlayers && totalPlayers > 0;
 
   function selectQuestion(categoryId: string, questionId: string) {
-    socket.emit('host:selectQuestion', { sessionId: sessionId!, hostToken: hostToken!, categoryId, questionId });
+    hostActions.selectQuestion(categoryId, questionId);
   }
   function judge(playerId: string, correct: boolean) {
-    socket.emit('host:judge', { sessionId: sessionId!, hostToken: hostToken!, playerId, correct });
+    hostActions.judge(playerId, correct);
   }
   function skipPlayer(playerId: string) {
-    socket.emit('host:skipPlayer', { sessionId: sessionId!, hostToken: hostToken!, playerId });
+    hostActions.skipPlayer(playerId);
   }
   function clearQuestion() {
-    if (autoReveal) {
-      socket.emit('host:clearQuestion', { sessionId: sessionId!, hostToken: hostToken! });
-    } else {
-      socket.emit('host:clearQuestionNoReveal', { sessionId: sessionId!, hostToken: hostToken! });
-    }
+    hostActions.clearQuestion(autoReveal);
   }
   function timerControl(action: 'pause' | 'resume' | 'extend' | 'set', seconds?: number) {
-    socket.emit('host:timerControl', { sessionId: sessionId!, hostToken: hostToken!, action, seconds });
+    hostActions.timerControl(action, seconds);
   }
   function continueBoard() {
-    socket.emit('host:continueBoard', { sessionId: sessionId!, hostToken: hostToken! });
+    hostActions.continueBoard();
   }
   function assignDouble(playerId: string) {
-    socket.emit('host:assignDouble', { sessionId: sessionId!, hostToken: hostToken!, playerId });
+    hostActions.assignDouble(playerId);
   }
   function setChallenge(challengedId: string) {
-    socket.emit('host:setChallenge', { sessionId: sessionId!, hostToken: hostToken!, challengedId });
+    hostActions.setChallenge(challengedId);
   }
   function revealFinal(playerId: string, isCorrect: boolean) {
-    socket.emit('host:revealFinal', { sessionId: sessionId!, hostToken: hostToken!, playerId, isCorrect });
+    hostActions.revealFinal(playerId, isCorrect);
   }
   function confirmEndGame() {
-    socket.emit('host:endGame', { sessionId: sessionId!, hostToken: hostToken! });
+    hostActions.endGame();
     setShowEndConfirm(false);
   }
 
@@ -260,7 +136,7 @@ export function HostBoardView() {
                 style={{ border: '1px solid rgba(255,200,87,0.5)', color: '#ffc857', background: 'rgba(255,200,87,0.08)' }}
                 onMouseEnter={(e) => { (e.currentTarget as HTMLElement).style.background = 'rgba(255,200,87,0.18)'; }}
                 onMouseLeave={(e) => { (e.currentTarget as HTMLElement).style.background = 'rgba(255,200,87,0.08)'; }}
-                onClick={() => socket.emit('host:startFinal', { sessionId: sessionId!, hostToken: hostToken! })}
+                onClick={hostActions.startFinal}
               >
                 {t('host_board.final_challenge')}
               </button>
@@ -363,7 +239,7 @@ export function HostBoardView() {
               {/* Audio player — clue (hidden during answer reveal) */}
               {activeQuestion.question.clueAudio && phase !== 'answer_reveal' && (
                 <div className="mt-6 w-full max-w-lg z-10">
-                  <AudioPlayer
+                  <SyncedAudioPlayer
                     src={`/media/${gameConfig.id}/${activeQuestion.question.clueAudio.filename}`}
                     audioRef={audioCallbackRef}
                     onPlay={() => emitAudio('play')}
@@ -418,7 +294,7 @@ export function HostBoardView() {
               {/* Answer audio */}
               {phase === 'answer_reveal' && activeQuestion.question.answerAudio && (
                 <div className="mt-4 w-full max-w-lg z-10">
-                  <AudioPlayer
+                  <SyncedAudioPlayer
                     src={`/media/${gameConfig.id}/${activeQuestion.question.answerAudio.filename}`}
                     audioRef={audioCallbackRef}
                     onPlay={() => emitAudio('play')}
@@ -879,11 +755,7 @@ export function HostBoardView() {
                         padding: '8px 16px', color: '#6b6390', fontSize: 12,
                         fontFamily: 'DM Sans, sans-serif', cursor: 'pointer',
                       }}
-                      onClick={() => socket.emit('host:revealFinal', {
-                        sessionId: sessionId!, hostToken: hostToken!,
-                        playerId: wagersSubmitted.find((w) => hostWagers[w.playerId])?.playerId ?? '',
-                        isCorrect: false,
-                      })}
+                      onClick={() => revealFinal(wagersSubmitted.find((w) => hostWagers[w.playerId])?.playerId ?? '', false)}
                     >
                       {t('host_board.reveal_anyway', { count: totalWagered, total: totalPlayers })}
                     </button>

--- a/packages/client/src/views/player/PlayerGameView.tsx
+++ b/packages/client/src/views/player/PlayerGameView.tsx
@@ -5,28 +5,12 @@ import { socket } from '../../socket.js';
 import { useGameStore } from '../../store/gameStore.js';
 import { usePlayerStore } from '../../store/playerStore.js';
 import { useSocketEvents } from '../../hooks/useSocketEvents.js';
+import { usePlayerActions } from '../../hooks/usePlayerActions.js';
 import { GameBoard } from '../../components/board/GameBoard.js';
 import { BuzzeLogo } from '../../components/ui/BuzzeLogo.js';
 import { useTranslation } from 'react-i18next';
 import { QuestionTimer } from '../../components/question/QuestionTimer.js';
-
-function Avatar({ name, color, size = 32 }: { name: string; color: string; size?: number }) {
-  return (
-    <div
-      style={{
-        width: size, height: size, borderRadius: '50%',
-        background: color, color: '#07060f',
-        display: 'flex', alignItems: 'center', justifyContent: 'center',
-        fontFamily: 'Syne, system-ui, sans-serif',
-        fontWeight: 800, fontSize: Math.round(size * 0.43),
-        flexShrink: 0,
-        boxShadow: `0 0 8px ${color}80`,
-      }}
-    >
-      {name.charAt(0).toUpperCase()}
-    </div>
-  );
-}
+import { PlayerAvatar as Avatar } from '../../components/ui/PlayerAvatar.js';
 
 export function PlayerGameView() {
   const { t } = useTranslation();
@@ -39,6 +23,7 @@ export function PlayerGameView() {
     challengeState, reset: resetGame,
   } = useGameStore();
   const { myId, myName, buzzerPosition, setBuzzerPosition } = usePlayerStore();
+  const playerActions = usePlayerActions({ sessionId: sessionId ?? '', playerId: myId ?? '' });
   const [wagerAmount, setWagerAmount] = useState('');
   const [wagerAnswer, setWagerAnswer] = useState('');
   const [wagerStep, setWagerStep] = useState<'bet' | 'answer'>('bet');
@@ -93,14 +78,14 @@ export function PlayerGameView() {
 
   function buzz() {
     if (!sessionId || !myId) return;
-    socket.emit('player:buzz', { sessionId, playerId: myId });
+    playerActions.buzz();
   }
 
   function submitWager(e: React.FormEvent) {
     e.preventDefault();
     if (!sessionId || !myId) return;
     const amount = Math.max(0, parseInt(wagerAmount) || 0);
-    socket.emit('player:finalWager', { sessionId, playerId: myId, amount });
+    playerActions.submitFinalWager(amount);
     setMyWagerSent();
   }
 
@@ -108,7 +93,7 @@ export function PlayerGameView() {
     e.preventDefault();
     if (!sessionId || !myId) return;
     const amount = Math.max(0, parseInt(doubleWagerInput) || 0);
-    socket.emit('player:doubleWager', { sessionId, playerId: myId, amount });
+    playerActions.submitDoubleWager(amount);
     setDoubleWagerSent(true);
   }
 
@@ -183,7 +168,7 @@ export function PlayerGameView() {
   function submitSpeedAnswer(e: React.FormEvent) {
     e.preventDefault();
     if (!speedInput.trim() || !sessionId || !myId) return;
-    socket.emit('player:speedAnswer', { sessionId, answer: speedInput.trim() });
+    playerActions.submitSpeedAnswer(speedInput.trim());
     setSpeedInput('');
   }
 

--- a/packages/server/src/__tests__/domain/buzzerRules.test.ts
+++ b/packages/server/src/__tests__/domain/buzzerRules.test.ts
@@ -1,0 +1,133 @@
+import { describe, expect, it } from 'vitest';
+import type { ActiveQuestion, BuzzerEntry } from '@buzze/shared';
+import { applyJudgeResult, applySpeedAnswer, clampDoubleWager } from '../../domain/buzzerRules.js';
+import { makePlayer, makeSession } from '../helpers/sessionFixture.js';
+
+function activeQuestion(overrides: Partial<ActiveQuestion> = {}): ActiveQuestion {
+  return {
+    categoryId: 'cat-1',
+    questionId: 'q-1',
+    question: { id: 'q-1', value: 100, clue: 'Q1', answer: 'Answer', type: 'standard', used: false },
+    startedAt: 1,
+    timerDuration: 30000,
+    ...overrides,
+  };
+}
+
+function queueEntry(playerId: string, playerName = playerId): BuzzerEntry {
+  return { playerId, playerName, timestamp: 1, responded: false };
+}
+
+describe('buzzerRules', () => {
+  it('scores a standard correct answer and moves to answer reveal', () => {
+    const session = makeSession({
+      activeQuestion: activeQuestion(),
+      buzzerQueue: [queueEntry('player-1', 'Alice')],
+      phase: 'buzzer_queue',
+    });
+
+    const result = applyJudgeResult(session, { playerId: 'player-1', correct: true });
+
+    expect(result.phase).toBe('answer_reveal');
+    expect(result.scoreChange).toBe(100);
+    expect(result.newScore).toBe(600);
+    expect(result.players['player-1'].score).toBe(600);
+    expect(result.nextInQueue).toBeNull();
+  });
+
+  it('keeps the buzzer queue open for the next player after a wrong standard answer', () => {
+    const session = makeSession({
+      activeQuestion: activeQuestion(),
+      buzzerQueue: [queueEntry('player-1', 'Alice'), queueEntry('player-2', 'Bob')],
+      phase: 'buzzer_queue',
+    });
+
+    const result = applyJudgeResult(session, { playerId: 'player-1', correct: false });
+
+    expect(result.phase).toBe('buzzer_queue');
+    expect(result.scoreChange).toBe(-100);
+    expect(result.players['player-1'].score).toBe(400);
+    expect(result.nextInQueue?.playerId).toBe('player-2');
+    expect(result.buzzerQueue[0]?.responded).toBe(true);
+  });
+
+  it('blocks an all-play player after a wrong answer without closing until all players are locked', () => {
+    const session = makeSession({
+      activeQuestion: activeQuestion({
+        question: { id: 'q-2', value: 200, clue: 'Q2', answer: 'A2', type: 'all_play', used: false },
+        lockedPlayerIds: [],
+      }),
+      buzzerQueue: [queueEntry('player-1', 'Alice')],
+      phase: 'buzzer_queue',
+    });
+
+    const result = applyJudgeResult(session, { playerId: 'player-1', correct: false });
+
+    expect(result.phase).toBe('all_play');
+    expect(result.closeQuestion).toBe(false);
+    expect(result.activeQuestion.lockedPlayerIds).toEqual(['player-1']);
+    expect(result.buzzerQueue).toEqual([]);
+  });
+
+  it('applies symmetric challenge scoring', () => {
+    const session = makeSession({
+      activeQuestion: activeQuestion({
+        question: { id: 'q-4', value: 400, clue: 'Q4', answer: 'A4', type: 'challenge', used: false },
+      }),
+      players: {
+        challenger: makePlayer('challenger', 'Challenger', 900),
+        challenged: makePlayer('challenged', 'Challenged', 100),
+      },
+      challengeState: {
+        challengerId: 'challenger',
+        challengerName: 'Challenger',
+        challengedId: 'challenged',
+        challengedName: 'Challenged',
+      },
+      buzzerQueue: [queueEntry('challenger', 'Challenger')],
+      phase: 'buzzer_queue',
+    });
+
+    const result = applyJudgeResult(session, { playerId: 'challenged', correct: false });
+
+    expect(result.scoreChange).toBe(-400);
+    expect(result.players.challenged.score).toBe(-300);
+    expect(result.players.challenger.score).toBe(1300);
+    expect(result.phase).toBe('board');
+    expect(result.closeQuestion).toBe(true);
+  });
+
+  it('clamps double wagers to the higher of player score and question value with a minimum of 50', () => {
+    expect(clampDoubleWager({ requestedAmount: 10, playerScore: 20, questionValue: 300 })).toBe(50);
+    expect(clampDoubleWager({ requestedAmount: 999, playerScore: 200, questionValue: 300 })).toBe(300);
+    expect(clampDoubleWager({ requestedAmount: 999, playerScore: 700, questionValue: 300 })).toBe(700);
+  });
+
+  it('accepts a first speed-round correct answer and awards full value', () => {
+    const session = makeSession({
+      activeQuestion: activeQuestion({
+        question: { id: 'q-5', value: 500, clue: 'Q5', answer: 'Banana', type: 'speed_round', used: false },
+        speedRoundCorrect: [],
+      }),
+      phase: 'speed_round',
+    });
+
+    const result = applySpeedAnswer(session, {
+      playerId: 'player-1',
+      answer: ' banana ',
+      timestamp: 123,
+    });
+
+    expect(result.accepted).toBe(true);
+    if (!result.accepted) throw new Error('Expected speed answer to be accepted.');
+    expect(result.phase).toBe('speed_round');
+    expect(result.scoreChange).toBe(500);
+    expect(result.players['player-1'].score).toBe(1000);
+    expect(result.activeQuestion.speedRoundCorrect?.[0]).toMatchObject({
+      playerId: 'player-1',
+      rank: 1,
+      scoreChange: 500,
+      timestamp: 123,
+    });
+  });
+});

--- a/packages/server/src/domain/buzzerRules.ts
+++ b/packages/server/src/domain/buzzerRules.ts
@@ -1,0 +1,178 @@
+import type { ActiveQuestion, BuzzerEntry, GamePhase, GameSession, Player, SpeedRoundCorrect } from '@buzze/shared';
+import { sanitizeAnswer } from '@buzze/shared';
+
+interface JudgeInput {
+  playerId: string;
+  correct: boolean;
+}
+
+interface JudgeResult {
+  phase: GamePhase;
+  players: Record<string, Player>;
+  buzzerQueue: BuzzerEntry[];
+  activeQuestion: ActiveQuestion;
+  scoreChange: number;
+  newScore: number;
+  nextInQueue: BuzzerEntry | null;
+  closeQuestion: boolean;
+}
+
+interface DoubleWagerInput {
+  requestedAmount: number;
+  playerScore: number;
+  questionValue: number;
+}
+
+interface SpeedAnswerInput {
+  playerId: string;
+  answer: string;
+  timestamp: number;
+}
+
+interface SpeedAnswerIgnored {
+  accepted: false;
+}
+
+interface SpeedAnswerAccepted {
+  accepted: true;
+  phase: GamePhase;
+  players: Record<string, Player>;
+  activeQuestion: ActiveQuestion;
+  scoreChange: number;
+  closeQuestion: boolean;
+}
+
+export function clampDoubleWager({ requestedAmount, playerScore, questionValue }: DoubleWagerInput): number {
+  const maxWager = Math.max(playerScore, questionValue);
+  return Math.max(50, Math.min(requestedAmount, maxWager));
+}
+
+export function applyJudgeResult(session: GameSession, input: JudgeInput): JudgeResult {
+  const activeQuestion = session.activeQuestion;
+  if (!activeQuestion) throw new Error('Cannot judge without active question.');
+
+  const player = session.players[input.playerId];
+  if (!player) throw new Error('Cannot judge unknown player.');
+
+  const isChallenge = activeQuestion.question.type === 'challenge' &&
+    session.challengeState?.challengedId === input.playerId;
+
+  const players = { ...session.players };
+  const { scoreChange, newScore } = scoreJudgement(session, input, player, players, isChallenge);
+  const buzzerQueue = session.buzzerQueue.map((entry) =>
+    entry.playerId === input.playerId ? { ...entry, responded: true } : entry,
+  );
+
+  if (activeQuestion.question.type === 'all_play' && !input.correct && !isChallenge) {
+    const lockedPlayerIds = [...(activeQuestion.lockedPlayerIds ?? []), input.playerId];
+    const allLocked = lockedPlayerIds.length >= Object.keys(session.players).length;
+    return {
+      phase: allLocked ? 'answer_reveal' : 'all_play',
+      players,
+      buzzerQueue: [],
+      activeQuestion: { ...activeQuestion, lockedPlayerIds },
+      scoreChange,
+      newScore,
+      nextInQueue: null,
+      closeQuestion: allLocked,
+    };
+  }
+
+  const nextInQueue = isChallenge ? null : (buzzerQueue.find((entry) => !entry.responded) ?? null);
+  const phase = input.correct ? 'answer_reveal' : (nextInQueue ? 'buzzer_queue' : 'board');
+
+  return {
+    phase,
+    players,
+    buzzerQueue,
+    activeQuestion,
+    scoreChange,
+    newScore,
+    nextInQueue,
+    closeQuestion: input.correct || !nextInQueue,
+  };
+}
+
+export function applySpeedAnswer(
+  session: GameSession,
+  input: SpeedAnswerInput,
+): SpeedAnswerIgnored | SpeedAnswerAccepted {
+  const activeQuestion = session.activeQuestion;
+  if (!activeQuestion) return { accepted: false };
+
+  const player = session.players[input.playerId];
+  if (!player) return { accepted: false };
+
+  const correct = sanitizeAnswer(input.answer).toLowerCase() ===
+    sanitizeAnswer(activeQuestion.question.answer).toLowerCase();
+  if (!correct) return { accepted: false };
+
+  const alreadyCorrect = activeQuestion.speedRoundCorrect ?? [];
+  if (alreadyCorrect.some((entry) => entry.playerId === input.playerId)) return { accepted: false };
+
+  const rank = alreadyCorrect.length + 1;
+  const scoreChange = Math.round(activeQuestion.question.value * speedRoundMultiplier(rank));
+  const entry: SpeedRoundCorrect = {
+    playerId: input.playerId,
+    playerName: player.name,
+    scoreChange,
+    rank,
+    timestamp: input.timestamp,
+  };
+
+  const speedRoundCorrect = [...alreadyCorrect, entry];
+  const players = { ...session.players };
+  if (scoreChange > 0) {
+    players[input.playerId] = { ...player, score: player.score + scoreChange };
+  }
+
+  const closeQuestion = speedRoundCorrect.length >= 3;
+  return {
+    accepted: true,
+    phase: closeQuestion ? 'answer_reveal' : 'speed_round',
+    players,
+    activeQuestion: { ...activeQuestion, speedRoundCorrect },
+    scoreChange,
+    closeQuestion,
+  };
+}
+
+function scoreJudgement(
+  session: GameSession,
+  input: JudgeInput,
+  player: Player,
+  players: Record<string, Player>,
+  isChallenge: boolean,
+): { scoreChange: number; newScore: number } {
+  const activeQuestion = session.activeQuestion;
+  if (!activeQuestion) throw new Error('Cannot score without active question.');
+
+  if (isChallenge && session.challengeState) {
+    const challenger = session.players[session.challengeState.challengerId];
+    const value = activeQuestion.question.value;
+    const scoreChange = input.correct ? value : -value;
+    players[input.playerId] = { ...player, score: player.score + scoreChange };
+    if (challenger) {
+      players[session.challengeState.challengerId] = {
+        ...challenger,
+        score: challenger.score + (input.correct ? -value : value),
+      };
+    }
+    return { scoreChange, newScore: players[input.playerId].score };
+  }
+
+  const wager = activeQuestion.question.type === 'double' && session.doubleWager !== null
+    ? session.doubleWager
+    : activeQuestion.question.value;
+  const scoreChange = input.correct ? wager : -wager;
+  const newScore = player.score + scoreChange;
+  players[input.playerId] = { ...player, score: newScore };
+  return { scoreChange, newScore };
+}
+
+function speedRoundMultiplier(rank: number): number {
+  if (rank === 1) return 1;
+  if (rank === 2) return 0.75;
+  if (rank === 3) return 0.5;
+  return 0;
+}

--- a/packages/server/src/handlers/buzzerHandler.ts
+++ b/packages/server/src/handlers/buzzerHandler.ts
@@ -1,28 +1,11 @@
 import type { Server, Socket } from 'socket.io';
-import type { ServerToClientEvents, ClientToServerEvents, BuzzerEntry, SpeedRoundCorrect } from '@buzze/shared';
-import { sanitizeAnswer } from '@buzze/shared';
+import type { ServerToClientEvents, ClientToServerEvents, BuzzerEntry } from '@buzze/shared';
 import { getSession, updateSession } from '../managers/sessionManager.js';
-import { validateHostToken } from '../middleware/authMiddleware.js';
 import { socketRateLimit } from '../middleware/rateLimiter.js';
 import { closeQuestion } from './gameHandler.js';
 import { startTimer } from '../managers/timerManager.js';
-
-function requireHost(
-  socket: Socket,
-  sessionId: string,
-  hostToken: string,
-): ReturnType<typeof getSession> | null {
-  const session = getSession(sessionId);
-  if (!session) {
-    socket.emit('error', { code: 'SESSION_NOT_FOUND', message: 'Sessão não encontrada.' });
-    return null;
-  }
-  if (session.hostId !== socket.id || !validateHostToken(session.hostToken, hostToken)) {
-    socket.emit('error', { code: 'NOT_HOST', message: 'Ação não permitida.' });
-    return null;
-  }
-  return session;
-}
+import { applyJudgeResult, applySpeedAnswer, clampDoubleWager } from '../domain/buzzerRules.js';
+import { requireHost } from './requireHost.js';
 
 export function registerBuzzerHandlers(
   io: Server<ClientToServerEvents, ServerToClientEvents>,
@@ -104,118 +87,62 @@ export function registerBuzzerHandlers(
     const player = session.players[payload.playerId];
     if (!player) return;
 
-    const updatedPlayers = { ...session.players };
-
-    let scoreChange: number;
-    let newScore: number;
-
-    if (isChallenge && session.challengeState) {
-      // Scoring simétrico 100%: ambos arriscam o valor cheio da questão
-      const challenger = session.players[session.challengeState.challengerId];
-      const value = activeQuestion.question.value;
-      if (payload.correct) {
-        // Desafiado acerta: +value; desafiador perde value
-        scoreChange = value;
-        updatedPlayers[payload.playerId] = { ...player, score: player.score + value };
-        if (challenger) {
-          updatedPlayers[session.challengeState.challengerId] = {
-            ...challenger,
-            score: challenger.score - value,
-          };
-        }
-      } else {
-        // Desafiado erra: -value; desafiador ganha value
-        scoreChange = -value;
-        updatedPlayers[payload.playerId] = { ...player, score: player.score - value };
-        if (challenger) {
-          updatedPlayers[session.challengeState.challengerId] = {
-            ...challenger,
-            score: challenger.score + value,
-          };
-        }
-      }
-      newScore = updatedPlayers[payload.playerId].score;
-    } else if (activeQuestion.question.type === 'double' && session.doubleWager !== null) {
-      // Scoring de Dupla Aposta: usa o valor apostado
-      scoreChange = payload.correct ? session.doubleWager : -session.doubleWager;
-      newScore = player.score + scoreChange;
-      updatedPlayers[payload.playerId] = { ...player, score: newScore };
-    } else {
-      // Scoring padrão
-      scoreChange = payload.correct ? activeQuestion.question.value : -activeQuestion.question.value;
-      newScore = player.score + scoreChange;
-      updatedPlayers[payload.playerId] = { ...player, score: newScore };
-    }
-
-    // Marcar como respondido na fila (se estiver)
-    const updatedQueue = session.buzzerQueue.map((e) =>
-      e.playerId === payload.playerId ? { ...e, responded: true } : e,
-    );
-
-    const isAllPlay = activeQuestion.question.type === 'all_play';
+    const result = applyJudgeResult(session, {
+      playerId: payload.playerId,
+      correct: payload.correct,
+    });
 
     // all_play com erro: bloquear player e reabrir buzzer
-    if (isAllPlay && !payload.correct && !isChallenge) {
-      const lockedPlayerIds = [...(activeQuestion.lockedPlayerIds ?? []), payload.playerId];
-      const totalPlayers = Object.keys(session.players).length;
-      const allLocked = lockedPlayerIds.length >= totalPlayers;
-      const newPhase = allLocked ? 'answer_reveal' : 'all_play';
-
-      const updatedActiveQuestion = { ...activeQuestion, lockedPlayerIds };
+    if (activeQuestion.question.type === 'all_play' && !payload.correct && !isChallenge) {
       updateSession(payload.sessionId, {
-        phase: newPhase,
-        players: updatedPlayers,
-        buzzerQueue: [],
-        activeQuestion: updatedActiveQuestion,
+        phase: result.phase,
+        players: result.players,
+        buzzerQueue: result.buzzerQueue,
+        activeQuestion: result.activeQuestion,
       });
 
       io.to(`session:${payload.sessionId}`).emit('judge:result', {
         playerId: payload.playerId,
         correct: false,
-        scoreChange,
-        newScore,
+        scoreChange: result.scoreChange,
+        newScore: result.newScore,
         nextInQueue: null,
-        phase: newPhase,
+        phase: result.phase,
       });
       io.to(`session:${payload.sessionId}`).emit('score:update', {
-        players: Object.values(updatedPlayers),
+        players: Object.values(result.players),
       });
 
-      if (allLocked) {
+      if (result.closeQuestion) {
         closeQuestion(io, payload.sessionId, true);
       }
       return;
     }
 
-    const nextInQueue = isChallenge ? null : (updatedQueue.find((e) => !e.responded) ?? null);
-    const newPhase = payload.correct ? 'answer_reveal' : (nextInQueue ? 'buzzer_queue' : 'board');
-
     updateSession(payload.sessionId, {
-      phase: newPhase,
-      players: updatedPlayers,
-      buzzerQueue: updatedQueue,
+      phase: result.phase,
+      players: result.players,
+      buzzerQueue: result.buzzerQueue,
     });
 
     io.to(`session:${payload.sessionId}`).emit('judge:result', {
       playerId: payload.playerId,
       correct: payload.correct,
-      scoreChange,
-      newScore,
-      nextInQueue,
-      phase: newPhase,
+      scoreChange: result.scoreChange,
+      newScore: result.newScore,
+      nextInQueue: result.nextInQueue,
+      phase: result.phase,
     });
 
     io.to(`session:${payload.sessionId}`).emit('score:update', {
-      players: Object.values(updatedPlayers),
+      players: Object.values(result.players),
     });
 
-    if (payload.correct) {
-      closeQuestion(io, payload.sessionId, true);
-    } else if (!nextInQueue) {
+    if (result.closeQuestion) {
       closeQuestion(io, payload.sessionId, true);
     } else {
       io.to(`host:${payload.sessionId}`).emit('buzzer:queueUpdate', {
-        queue: updatedQueue,
+        queue: result.buzzerQueue,
         phase: 'buzzer_queue',
       });
     }
@@ -267,11 +194,11 @@ export function registerBuzzerHandlers(
     const activeQuestion = session.activeQuestion;
     if (!activeQuestion) return;
 
-    // Saldo negativo: pode apostar até o valor da questão (chance de recuperar)
-    // Saldo positivo: pode apostar até o saldo atual
-    // Mínimo sempre 50
-    const maxWager = Math.max(player.score, activeQuestion.question.value);
-    const amount = Math.max(50, Math.min(payload.amount, maxWager));
+    const amount = clampDoubleWager({
+      requestedAmount: payload.amount,
+      playerScore: player.score,
+      questionValue: activeQuestion.question.value,
+    });
 
     // Salva aposta e transita para question (clue revela para todos, timer inicia)
     updateSession(payload.sessionId, {
@@ -314,58 +241,31 @@ export function registerBuzzerHandlers(
     const activeQuestion = session.activeQuestion;
     if (!activeQuestion) return;
 
-    const correct = sanitizeAnswer(payload.answer).toLowerCase() === sanitizeAnswer(activeQuestion.question.answer).toLowerCase();
-    if (!correct) return; // errou: tentativas livres, sem penalidade
-
-    const alreadyCorrect = activeQuestion.speedRoundCorrect ?? [];
-
-    // Player já acertou antes — ignorar
-    if (alreadyCorrect.some((e) => e.playerId === socket.id)) return;
-
-    // Rank: quantos já acertaram + 1
-    const rank = alreadyCorrect.length + 1;
-
-    // Pontuação: 1º=100%, 2º=75%, 3º=50%, demais=0
-    const RANK_MULTIPLIERS: Record<number, number> = { 1: 1, 2: 0.75, 3: 0.5 };
-    const multiplier = RANK_MULTIPLIERS[rank] ?? 0;
-    const scoreChange = Math.round(activeQuestion.question.value * multiplier);
-
-    const entry: SpeedRoundCorrect = {
+    const result = applySpeedAnswer(session, {
       playerId: socket.id,
-      playerName: player.name,
-      scoreChange,
-      rank,
+      answer: payload.answer,
       timestamp: Date.now(),
-    };
-
-    const updatedCorrect = [...alreadyCorrect, entry];
-    const updatedPlayers = { ...session.players };
-    if (scoreChange > 0) {
-      updatedPlayers[socket.id] = { ...player, score: player.score + scoreChange };
-    }
-
-    const updatedActiveQuestion = { ...activeQuestion, speedRoundCorrect: updatedCorrect };
-    const allPlayersScored = updatedCorrect.length >= 3; // rank 3 = encerrar early
-    const newPhase = allPlayersScored ? 'answer_reveal' : 'speed_round';
+    });
+    if (!result.accepted) return;
 
     updateSession(payload.sessionId, {
-      players: updatedPlayers,
-      activeQuestion: updatedActiveQuestion,
-      ...(allPlayersScored ? { phase: 'answer_reveal' } : {}),
+      players: result.players,
+      activeQuestion: result.activeQuestion,
+      ...(result.closeQuestion ? { phase: 'answer_reveal' } : {}),
     });
 
     io.to(`session:${payload.sessionId}`).emit('speed:answered', {
-      correct: updatedCorrect,
-      phase: newPhase,
+      correct: result.activeQuestion.speedRoundCorrect ?? [],
+      phase: result.phase,
     });
 
-    if (scoreChange > 0) {
+    if (result.scoreChange > 0) {
       io.to(`session:${payload.sessionId}`).emit('score:update', {
-        players: Object.values(updatedPlayers),
+        players: Object.values(result.players),
       });
     }
 
-    if (allPlayersScored) {
+    if (result.closeQuestion) {
       closeQuestion(io, payload.sessionId, true);
     }
   });

--- a/packages/server/src/handlers/finalHandler.ts
+++ b/packages/server/src/handlers/finalHandler.ts
@@ -2,26 +2,9 @@ import type { Server, Socket } from 'socket.io';
 import type { ServerToClientEvents, ClientToServerEvents } from '@buzze/shared';
 import { sanitizeAnswer } from '@buzze/shared';
 import { getSession, updateSession } from '../managers/sessionManager.js';
-import { validateHostToken } from '../middleware/authMiddleware.js';
 import { canTransition } from '../managers/gameStateManager.js';
 import { startTimer, stopTimer } from '../managers/timerManager.js';
-
-function requireHost(
-  socket: Socket,
-  sessionId: string,
-  hostToken: string,
-): ReturnType<typeof getSession> | null {
-  const session = getSession(sessionId);
-  if (!session) {
-    socket.emit('error', { code: 'SESSION_NOT_FOUND', message: 'Sessão não encontrada.' });
-    return null;
-  }
-  if (session.hostId !== socket.id || !validateHostToken(session.hostToken, hostToken)) {
-    socket.emit('error', { code: 'NOT_HOST', message: 'Ação não permitida.' });
-    return null;
-  }
-  return session;
-}
+import { requireHost } from './requireHost.js';
 
 /** Emite os eventos de início do Desafio Final para todos + detalhes ao host */
 export function emitFinalChallengeStart(

--- a/packages/server/src/handlers/gameHandler.ts
+++ b/packages/server/src/handlers/gameHandler.ts
@@ -1,28 +1,11 @@
 import type { Server, Socket } from 'socket.io';
 import type { ServerToClientEvents, ClientToServerEvents, GameConfig } from '@buzze/shared';
 import { getSession, updateSession } from '../managers/sessionManager.js';
-import { validateHostToken } from '../middleware/authMiddleware.js';
 import { canTransition, allQuestionsUsed } from '../managers/gameStateManager.js';
 import { emitFinalChallengeStart } from './finalHandler.js';
 import { startTimer, stopTimer, pauseTimer, resumeTimer, extendTimer, setTimer } from '../managers/timerManager.js';
 import { DEFAULT_TIMER_MS } from '../config.js';
-
-function requireHost(
-  socket: Socket,
-  sessionId: string,
-  hostToken: string,
-): ReturnType<typeof getSession> | null {
-  const session = getSession(sessionId);
-  if (!session) {
-    socket.emit('error', { code: 'SESSION_NOT_FOUND', message: 'Sessão não encontrada.' });
-    return null;
-  }
-  if (session.hostId !== socket.id || !validateHostToken(session.hostToken, hostToken)) {
-    socket.emit('error', { code: 'NOT_HOST', message: 'Ação não permitida.' });
-    return null;
-  }
-  return session;
-}
+import { requireHost } from './requireHost.js';
 
 export function registerGameHandlers(
   io: Server<ClientToServerEvents, ServerToClientEvents>,

--- a/packages/server/src/handlers/requireHost.ts
+++ b/packages/server/src/handlers/requireHost.ts
@@ -1,0 +1,21 @@
+import type { Socket } from 'socket.io';
+import type { ClientToServerEvents, ServerToClientEvents } from '@buzze/shared';
+import { getSession } from '../managers/sessionManager.js';
+import { validateHostToken } from '../middleware/authMiddleware.js';
+
+export function requireHost(
+  socket: Socket<ClientToServerEvents, ServerToClientEvents>,
+  sessionId: string,
+  hostToken: string,
+): ReturnType<typeof getSession> | null {
+  const session = getSession(sessionId);
+  if (!session) {
+    socket.emit('error', { code: 'SESSION_NOT_FOUND', message: 'Sessão não encontrada.' });
+    return null;
+  }
+  if (session.hostId !== socket.id || !validateHostToken(session.hostToken, hostToken)) {
+    socket.emit('error', { code: 'NOT_HOST', message: 'Ação não permitida.' });
+    return null;
+  }
+  return session;
+}


### PR DESCRIPTION
## Summary

This PR reduces complexity in the game flow code and addresses the client bundle warning.

### Server
- Extracts pure buzzer/game-rule logic into `packages/server/src/domain/buzzerRules.ts`.
- Adds focused tests for standard judging, all-play lock behavior, challenge scoring, double wager clamping, and speed-round scoring.
- Centralizes host validation in `packages/server/src/handlers/requireHost.ts`.
- Simplifies `buzzerHandler.ts` so socket handlers mostly validate, apply domain rules, update session state, and emit events.

### Client
- Adds route-level lazy loading in `App.tsx` to split the large initial bundle.
- Extracts shared UI components:
  - `PlayerAvatar`
  - `TimerCircle`
  - `SyncedAudioPlayer`
- Adds typed socket action hooks:
  - `useHostActions`
  - `usePlayerActions`
- Updates host/player/lobby views to use those extracted helpers instead of duplicating UI and raw socket emits.

### Bundle
- Initial client JS chunk is now below the 500 kB warning threshold.
- Latest build output shows the entry chunk at `251.97 kB` / `81.88 kB gzip`.

## Verification

Ran successfully:

```bash
pnpm type-check
pnpm test
pnpm build
```

Test count from the final run:
- shared: 29 tests
- client: 35 tests
- server: 179 tests
- electron: 11 tests

Total: 254 tests passing.
